### PR TITLE
Allow the overriding of the tekton bundle used for building components

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,3 +56,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/gitops/generate.go
+++ b/pkg/gitops/generate.go
@@ -20,6 +20,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	gitopsprepare "github.com/redhat-appstudio/build-service/pkg/gitops/prepare"
 	"github.com/redhat-appstudio/build-service/pkg/gitops/resources"
 	"github.com/spf13/afero"
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,7 +40,7 @@ const (
 
 // Generate takes in a given Component CR and
 // spits out a deployment, service, and route file to disk
-func Generate(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component) error {
+func Generate(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Component, config gitopsprepare.GitopsConfig) error {
 	deployment := generateDeployment(component)
 
 	k := resources.Kustomization{}
@@ -59,7 +60,7 @@ func Generate(fs afero.Fs, outputFolder string, component appstudiov1alpha1.Comp
 
 	tektonResourcesDirName := ".tekton"
 	k.AddResources(tektonResourcesDirName + "/")
-	if err := GenerateBuild(fs, filepath.Join(outputFolder, tektonResourcesDirName), component); err != nil {
+	if err := GenerateBuild(fs, filepath.Join(outputFolder, tektonResourcesDirName), component, config); err != nil {
 		return err
 	}
 

--- a/pkg/gitops/prepare/prepare.go
+++ b/pkg/gitops/prepare/prepare.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package prepare
+
+import (
+	"context"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// namespace where the bundle configuration will be searched in case it is not found in the component's namespace
+	BuildBundleDefaultNamepace = "build-templates"
+	// name for a configMap that holds the URL to a build bundle
+	BuildBundleConfigMapName = "build-pipelines-defaults"
+	// data key within a configMap that holds the URL to a build bundle
+	BuildBundleConfigMapKey = "default_build_bundle"
+	// fallback bundle that will be used in case the bundle resolution fails
+	FallbackBuildBundle = "quay.io/redhat-appstudio/build-templates-bundle:8201a567956ba6d2095d615ea2c0f6ab35f9ba5f"
+)
+
+// Holds data that needs to be queried from the cluster in order for the gitops generation function to work
+// This struct is left here so more data can be added as needed
+type GitopsConfig struct {
+	BuildBundle string
+}
+
+func PrepareGitopsConfig(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) GitopsConfig {
+	data := GitopsConfig{}
+
+	data.BuildBundle = resolveBuildBundle(ctx, cli, component)
+
+	return data
+}
+
+// Tries to load a custom build bundle path from a configmap.
+// The following priority is used: component's namespace -> default namespace -> fallback value.
+func resolveBuildBundle(ctx context.Context, cli client.Client, component appstudiov1alpha1.Component) string {
+	namespaces := [2]string{component.Namespace, BuildBundleDefaultNamepace}
+
+	for _, namespace := range namespaces {
+		var configMap = corev1.ConfigMap{}
+
+		// All errors during the loading of the configmaps should be treated as non-fatal
+		// TODO: Add logging to help the debugging of eventual issues
+		_ = cli.Get(ctx, types.NamespacedName{Name: BuildBundleConfigMapName, Namespace: namespace}, &configMap)
+
+		if value, isPresent := configMap.Data[BuildBundleConfigMapKey]; isPresent && value != "" {
+			return value
+		}
+	}
+
+	return FallbackBuildBundle
+}

--- a/pkg/gitops/prepare/prepare_test.go
+++ b/pkg/gitops/prepare/prepare_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package prepare
+
+import (
+	"context"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/build-service/pkg/gitops/testutils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestResolveBuildBundle(t *testing.T) {
+	var testData = corev1.ConfigMap{}
+
+	mockedClient := &testutils.MockedClient{}
+	mockedClient.MockedGet = func(obj client.Object) error {
+		c := obj.(*corev1.ConfigMap)
+		c.Data = testData.Data
+		c.ObjectMeta = testData.ObjectMeta
+		return nil
+	}
+
+	component := appstudiov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myName",
+			Namespace: "myNamespace",
+		},
+	}
+
+	tests := []struct {
+		name string
+		data corev1.ConfigMap
+		want string
+	}{
+		{
+			name: "should resolve the build bundle in case a configmap exists in the component's namespace",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "quay.io/foo/bar:ref",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: component.Namespace,
+				},
+			},
+			want: "quay.io/foo/bar:ref",
+		},
+		{
+			name: "should resolve the build bundle in case a configmap exists in the default namespace",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "quay.io/foo/bar:ref",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: "quay.io/foo/bar:ref",
+		},
+		{
+			name: "should fall back to the hard-coded bundle in case the resolution fails",
+			data: corev1.ConfigMap{},
+			want: FallbackBuildBundle,
+		},
+		{
+			name: "should ignore malformed configmaps",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					"invalidKey": "quay.io/foo/bar:ref",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: FallbackBuildBundle,
+		},
+		{
+			name: "should ignore configmaps with empty keys",
+			data: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				Data: map[string]string{
+					BuildBundleConfigMapKey: "",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BuildBundleConfigMapName,
+					Namespace: BuildBundleDefaultNamepace,
+				},
+			},
+			want: FallbackBuildBundle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testData = tt.data
+			if got := resolveBuildBundle(context.TODO(), mockedClient, component); got != tt.want {
+				t.Errorf("ResolveBuildBundle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/gitops/testutils/test_utils.go
+++ b/pkg/gitops/testutils/test_utils.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package testutils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Mocking of K8s client that allows unit testing functions that load cluster resources
+// The function variables are meant to be overriden during the tests runtime
+type MockedClient struct {
+	MockedGet func(obj client.Object) error
+}
+
+func (c MockedClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return nil
+}
+
+func (c MockedClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+
+func (c MockedClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+func (c MockedClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+	return c.MockedGet(obj)
+}
+
+func (c MockedClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+
+func (c MockedClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+func (c MockedClient) RESTMapper() meta.RESTMapper {
+	return nil
+}
+
+func (c MockedClient) Scheme() *runtime.Scheme {
+	return nil
+}
+
+func (c MockedClient) Status() client.StatusWriter {
+	return nil
+}
+
+func (c MockedClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return nil
+}


### PR DESCRIPTION
We need to [implement the concept of organizations](https://issues.redhat.com/browse/PLNSRVCE-56) and allow the sharing of build assets in a non-KCP world.

This PR is a first step in that direction, providing a simple mechanism to define a configmap that'll allow HAS to use a specific Tekton bundle instead of the default one.

Here's a sample configmap, which should be placed in the same namespace where the HAS application/component objects will be created.

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: build-pipelines-defaults
data:
  default_build_bundle: "quay.io/user/custombundle:version" 
```
In case this configmap is not available, the build service will try to search for one with the same name at the build-templates namespace, which is currently defined as default by the infra-deployments [configuration](https://github.com/redhat-appstudio/infra-deployments/blob/1c6328ee54c4ccde2d2bc58bd845d3eb024ae0f3/components/build/kustomization.yaml#L11).

If no configmap is found, it will resort to the one that's currently [hardcoded](https://github.com/redhat-appstudio/build-service/blob/44ea8271f5d2279fb65b7c93ba591136593d00b4/pkg/gitops/generate_build.go#L54).