### PR TITLE
update build-service to use PVC instead of volumeClaimTemplate

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -19,10 +19,6 @@ spec:
     bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
   workspaces:
     - name: workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes: 
-            - ReadWriteOnce
-          resources: 
-            requests: 
-              storage: 200Mi
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: build-service-check-{{ revision }}

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -19,10 +19,6 @@ spec:
     bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
   workspaces:
     - name: workspace
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 200Mi
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: build-service-push-{{ revision }}


### PR DESCRIPTION
### Description:
As PVC is created for the whole namespace and the pipelineRun is using subPath, the PVC was being full very soon, and to overcome this, as a workaround we used volumeClaimTemplate, which creates PVC for each pipelineRun.

Now, there is a [PVC-cleaner](https://github.com/redhat-appstudio/pvc-cleaner) which will delete the subPath when a pipelineRun is deleted.
This PR is to switch back to subPaths from volumeClaimTemplate.

### Link to JIRA Story:
https://issues.redhat.com/browse/PLNSRVCE-174