### PR TITLE
Don't generate build resources for Container Image Components

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -100,6 +100,12 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
+	// Do not run any builds for any container-image components
+	if component.Spec.Source.ImageSource != nil && component.Spec.Source.ImageSource.ContainerImage != "" {
+		log.Info(fmt.Sprintf("Nothing to do for container image component: %v", req.NamespacedName))
+		return ctrl.Result{}, nil
+	}
+
 	shouldBuild, err := r.IsNewBuildRequired(ctx, component)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
Since container image components don't have anything to build, there's no point generating build resources for them.

Note: I tried writing a test but couldn't get the tests to run on my machine, so I couldn't verify if it actually passed or not.