### PR TITLE
Allow the overriding of the default Tekton bundle

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,3 +23,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -36,6 +36,7 @@ import (
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops"
+	"github.com/redhat-appstudio/application-service/gitops/prepare"
 )
 
 const (
@@ -71,6 +72,7 @@ func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -184,7 +186,8 @@ func (r *ComponentBuildReconciler) SubmitNewBuild(ctx context.Context, component
 		}
 	}
 
-	initialBuild := gitops.GenerateInitialBuildPipelineRun(component)
+	gitopsConfig := prepare.PrepareGitopsConfig(ctx, r.Client, component)
+	initialBuild := gitops.GenerateInitialBuildPipelineRun(component, gitopsConfig)
 	err = controllerutil.SetOwnerReference(&component, &initialBuild, r.Scheme)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Unable to set owner reference for %v", initialBuild))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/redhat-appstudio/application-service v0.0.0-20220429161414-fd5f11553e0f
+	github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed
 	github.com/tektoncd/pipeline v0.33.0
 	github.com/tektoncd/triggers v0.19.1
 	k8s.io/api v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -1799,6 +1799,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-appstudio/application-service v0.0.0-20220429161414-fd5f11553e0f h1:+O6nY2rWbYMM8ak3f8UCoGQn9ULDbhB+WzNifJ/bi34=
 github.com/redhat-appstudio/application-service v0.0.0-20220429161414-fd5f11553e0f/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
+github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed h1:pImL7M8vIDPHGzA3dXW4Cqbb1XtvQQUN3wkFB+Iut98=
+github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.4.3/go.mod h1:hzWm/OOlLXmtF8Qwox3GZlfGJAjVM7KaRkbBjmYAI9k=
 github.com/redhat-developer/alizer/go v0.0.0-20220215154256-33df7feef4ae h1:N2wsIYtziHQ51GNcJY5YcB0YldpR5BwPoTvby+l0vy8=


### PR DESCRIPTION
PLNSRVCE-141

Allows the Tekton bundle used in the created PipelineRuns to be overriden.
Relates to https://github.com/redhat-appstudio/application-service/pull/106.