### PR TITLE
Add scripts for triggering build-service e2e test

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,22 @@
+# Build Service CI documentation
+
+Currently in build-service all tests are running in [Openshift CI](https://prow.ci.openshift.org/?job=*build*service*).
+
+## Openshift CI
+
+Openshift CI is a Kubernetes based CI/CD system. Jobs can be triggered by various types of events and report their status to many different services. In addition to job execution, Openshift CI provides GitHub automation in a form of policy enforcement, chat-ops via /foo style commands and automatic PR merging.
+
+A documentation around onboarding components in Openshift CI can be found in the Openshift CI jobs [repository](https://github.com/openshift/release). All build-service jobs configurations are defined in https://github.com/openshift/release/tree/master/ci-operator/config/redhat-appstudio/build-service.
+
+- `build-service-e2e`: Run build suite from [e2e-tests](https://github.com/redhat-appstudio/e2e-tests/pkg/tests/build) repository.
+
+The test container to run the e2e tests in Openshift Ci is built from: https://github.com/redhat-appstudio/build-service/blob/main/.ci/openshift-ci/Dockerfile
+
+The following environments are used to launch the CI tests in Openshift CI:
+
+| Variable | Required | Explanation | Default Value |
+|---|---|---|---|
+| `BUILD_SERVICE_IMAGE` | no | A valid build service container without tag. | `quay.io/redhat-appstudio/build-service` |
+| `BUILD_SERVICE_IMAGE_TAG` | no | A valid build service container tag. | `next` |
+| `GITHUB_TOKEN` | yes | A github token used to create AppStudio applications in GITHUB  | ''  |
+| `QUAY_TOKEN` | yes | A quay token to push components images to quay.io | '' |

--- a/.ci/oci-e2e-build-service.sh
+++ b/.ci/oci-e2e-build-service.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
+
+export WORKSPACE BUILD_SERVICE_PR_OWNER BUILD_SERVICE_PR_SHA
+
+WORKSPACE=$(dirname "$(dirname "$(readlink -f "$0")")");
+export TEST_SUITE="build-service-suite"
+export APPLICATION_NAMESPACE="openshift-gitops"
+export APPLICATION_NAME="all-components-staging"
+
+# BUILD_SERVICE_IMAGE - build-service image built in openshift CI job workflow. More info about how image dependencies work in ci: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
+# Container env defined at: https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/build-service/redhat-appstudio-build-service-main.yaml
+# Openshift CI generates the build service container image value as registry.build01.ci.openshift.org/ci-op-83gwcnmk/pipeline@sha256:8812e26b50b262d0cc45da7912970a205add4bd4e4ff3fed421baf3120027206. Need to get the image without sha.
+export BUILD_SERVICE_IMAGE_REPO=${BUILD_SERVICE_IMAGE%@*:-"quay.io/redhat-appstudio/build-service"}
+# Tag defined at: https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/build-service/redhat-appstudio-build-service-main.yaml
+export BUILD_SERVICE_IMAGE_TAG=${BUILD_SERVICE_IMAGE_TAG:-"redhat-appstudio-build-service-image"}
+
+if [ -n "${JOB_SPEC}" ]; then
+    # Extract PR author and commit SHA to also override default kustomization in infra-deployments repo
+    # https://github.com/redhat-appstudio/infra-deployments/blob/d3b56adc1bd2a7cf500793a7863660ea5117c531/hack/preview.sh#L88
+    BUILD_SERVICE_PR_OWNER=$(jq -r '.refs.pulls[0].author' <<< "$JOB_SPEC")
+    BUILD_SERVICE_PR_SHA=$(jq -r '.refs.pulls[0].sha' <<< "$JOB_SPEC")
+fi
+
+# Available openshift ci environments https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables
+export ARTIFACT_DIR=${ARTIFACT_DIR:-"/tmp/appstudio"}
+
+function waitHASApplicationToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io has -n openshift-gitops -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
+        echo "[INFO] Waiting for HAS to be ready."
+        sleep 30s
+    done
+}
+
+function waitAppStudioToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ] ||
+          [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.sync.status}')" != "Synced" ]; do
+        echo "[INFO] Waiting for AppStudio to be ready."
+        sleep 1m
+    done
+}
+
+function waitBuildToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io build -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ] ||
+          [ "$(kubectl get applications.argoproj.io build -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.sync.status}')" != "Synced" ]; do
+        echo "[INFO] Waiting for Build to be ready."
+        sleep 1m
+    done
+}
+
+function executeE2ETests() {
+    # E2E instructions can be found: https://github.com/redhat-appstudio/e2e-tests
+    # The e2e binary is included in Openshift CI test container from the dockerfile: https://github.com/redhat-appstudio/infra-deployments/blob/main/.ci/openshift-ci/Dockerfile
+    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/e2e-openshift-ci.sh | bash -s
+
+    # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
+    "${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio" --ginkgo.junit-report="${ARTIFACT_DIR}"/e2e-report.xml --ginkgo.focus="${TEST_SUITE}" --ginkgo.progress --ginkgo.v --ginkgo.no-color
+}
+
+curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/install-appstudio-e2e-mode.sh | bash -s install
+
+export -f waitAppStudioToBeReady
+export -f waitBuildToBeReady
+export -f waitHASApplicationToBeReady
+
+# Install AppStudio Controllers and wait for HAS and other AppStudio application to be running.
+timeout --foreground 10m bash -c waitAppStudioToBeReady
+timeout --foreground 10m bash -c waitBuildToBeReady
+timeout --foreground 10m bash -c waitHASApplicationToBeReady
+
+executeE2ETests

--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
+
+SHELL ["/bin/bash", "-c"]
+
+# Install yq, kubectl, kustomize
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && yq --version && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- gabemontero
+- goldmann
+- mmorhun
+- psturc
+
+approvers:
+- gabemontero
+- goldmann
+- mmorhun
+- psturc
+
+# 'Build team' members that are not members of openshift github org (could be added in a future):
+# - brunoapimentel
+# - ejegrova
+# - mbharatk
+# - Michkov
+# - stuartwdouglas


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLNSRVCE-185

### What was changed
Added Dockerfile and script to be used by OpenShift CI on a PR basis for running e2e tests

### Verification steps
Following steps will be run from inside the container we're going to build the image for
1. Build the image
```bash
docker build -t quay.io/psturc/build-service-openshift-ci-base-image:latest . -f .ci/openshift-ci/Dockerfile
```
2. Run the container from the image you just built, mount the current folder with the build-service repo contents and pass the env var `QUAY_TOKEN` with the base64 encoded dockerconfig file (make sure you're docker logged in to quay.io first)
```bash
docker run -e QUAY_TOKEN=$(base64 < ~/.docker/config.json) -v $(pwd):/go/src/github.com/openshift/origin -it quay.io/psturc/build-service-openshift-ci-base-image:latest /bin/bash
```
3. Update and export following env vars
```bash
# Please update these env var values
export GITHUB_E2E_ORGANIZATION=<your-github-org>
export QUAY_E2E_ORGANIZATION=<your-quay-org>
export GITHUB_TOKEN=<your-github-token-with-permissions-to-write-to-GITHUB_E2E_ORGANIZATION>
```
4. Install oc and login to your cluster
```bash
curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.10.5/openshift-client-linux.tar.gz | tar -zx && mv oc /usr/local/bin

oc login <your cluster>
```
5. Run
```bash
# OpenShift CI specific env vars updated for the purpose of this PR
export JOB_SPEC='{"refs":{"org":"redhat-appstudio","repo":"e2e-tests","repo_link":"https://github.com/redhat-appstudio/e2e-tests","base_ref":"main","base_sha":"2dcbde3b80153f7b27a45343a1277ca3cc524f39","base_link":"https://github.com/redhat-appstudio/e2e-tests/commit/ad3d0daf2bfa1f05413cc5fdb209fe880290cf88","pulls":[{"number":57,"author":"psturc","sha":"93d48f1a75216be4004014de478c4162b65c3ed0","title":"chore: use managed-gitops CR to deploy AppStudio Components in e2e","link":"https://github.com/redhat-appstudio/e2e-tests/pull/57","commit_link":"https://github.com/redhat-appstudio/e2e-tests/pull/57/commits/5138611931e74952cf28cf6a4f9715ccd6767b86","author_link":"https://github.com/albarbaro"}]}}'
export CLONEREFS_OPTIONS='{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"redhat-appstudio","repo":"build-service","repo_link":"https://github.com/redhat-appstudio/build-service","base_ref":"main","base_sha":"75a4c79e49ab5c1a4c15d844256d1e4419da63e3","base_link":"https://github.com/redhat-appstudio/build-service/commit/75a4c79e49ab5c1a4c15d844256d1e4419da63e3","pulls":[{"number":91,"author":"psturc","sha":"93d48f1a75216be4004014de478c4162b65c3ed0","link":"https://github.com/redhat-appstudio/application-service/pull/91","commit_link":"https://github.com/redhat-appstudio/application-service/pull/91/commits/47b9fe555e27cc65c5ebfcf51c2d26a036fab235","author_link":"https://github.com/psturc"}]}],"fail":true}'
export OPENSHIFT_CI=true
# Env vars with values set for the purpose of this PR
export BUILD_SERVICE_IMAGE=quay.io/redhat-appstudio/pull-request-builds
export BUILD_SERVICE_IMAGE_TAG=buildserv-93d48f1a75216be4004014de478c4162b65c3ed0
# References this PR number. It's required by this script: https://github.com/redhat-appstudio/e2e-tests/blob/main/scripts/install-appstudio-e2e-mode.sh
export PULL_NUMBER=13
export ARTIFACT_DIR=/tmp
# Set up github creds
git config --global credential.helper "store --file /tmp/github_creds"
echo "https://${GITHUB_E2E_ORGANIZATION}:${GITHUB_TOKEN}@github.com" > /tmp/github_creds
# Run this script
rm -rf tmp && ./.ci/oci-e2e-build-service.sh
```
6. This script should be able to deploy appstudio components from main branch on your cluster with these changes to a build-service:
* the deployed image on your cluster: `quay.io/redhat-appstudio/pull-request-builds:buildserv-93d48f1a75216be4004014de478c4162b65c3ed0`
* it will use kustomize config for build-service from $JOB_SPEC env var: `https://github.com/psturc/build-service/config/default?ref=93d48f1a75216be4004014de478c4162b65c3ed0`. [This is how it should look like in the preview branch](https://github.com/psturc-org/infra-deployments/commit/b7aaa934b51836202dceb923040acc77dd433727#diff-5c93bf47073dc33e77c2f62d49686f096901505d3c52a8f28c7c44457b07ed8cR3)
7. It should be also able to run build-service test suite, run it and it should finish successfully