### PR TITLE
Do not use cache when interactinig with git repository secret

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -46,9 +46,10 @@ const (
 
 // ComponentBuildReconciler watches AppStudio Component object in order to submit builds
 type ComponentBuildReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
-	Log    logr.Logger
+	Client           client.Client
+	NonCachingClient client.Client
+	Scheme           *runtime.Scheme
+	Log              logr.Logger
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -169,7 +170,7 @@ func (r *ComponentBuildReconciler) SubmitNewBuild(ctx context.Context, component
 	// Make the Secret ready for consumption by Tekton.
 	if gitSecretName != "" {
 		gitSecret := corev1.Secret{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: gitSecretName, Namespace: component.Namespace}, &gitSecret)
+		err := r.NonCachingClient.Get(ctx, types.NamespacedName{Name: gitSecretName, Namespace: component.Namespace}, &gitSecret)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Secret %s is missing", gitSecretName))
 			return err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -107,9 +107,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&ComponentBuildReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ComponentInitialBuild"),
+		Client:           k8sManager.GetClient(),
+		NonCachingClient: k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		Log:              ctrl.Log.WithName("controllers").WithName("ComponentInitialBuild"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -90,10 +91,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	nonCachingClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to initialize non cached client")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.ComponentBuildReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ComponentInitialBuild"),
+		Client:           mgr.GetClient(),
+		NonCachingClient: nonCachingClient,
+		Scheme:           mgr.GetScheme(),
+		Log:              ctrl.Log.WithName("controllers").WithName("ComponentInitialBuild"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ComponentInitialBuild")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

On a cluster with huge number of secrets default cache system of operator causes OOM.
As the secret with git credentials has no obligations and initial build happens once per component, we can use non-caching k8s client to avoid this issue.