### PR TITLE
removed deploy-key secret

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -25,6 +25,3 @@ spec:
       persistentVolumeClaim:
         claimName: app-studio-default-workspace
       subPath: build-service-push-{{ revision }}
-    - name: deploy-key
-      secret:
-        secretName: infra-deployments-deploy-key


### PR DESCRIPTION
This PR deletes the infra-deployments-deploy-key secret, as there is a sharedSecret created for all the namespaces, there is no need for an individual secret to be added to each namespace.