### PR TITLE
fix the pipeline build on image source

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -98,7 +98,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Do not run any builds for any container-image components
-	if component.Spec.Source.ImageSource != nil && component.Spec.Source.ImageSource.ContainerImage != "" {
+	if component.Spec.ContainerImage != "" && component.Spec.Source.GitSource == nil {
 		log.Info(fmt.Sprintf("Nothing to do for container image component: %v", req.NamespacedName))
 		return ctrl.Result{}, nil
 	}

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -232,15 +232,9 @@ var _ = Describe("Component initial build controller", func() {
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName: HASCompName,
-					Application:   HASAppName,
-					Source: appstudiov1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-							ImageSource: &appstudiov1alpha1.ImageSource{
-								ContainerImage: "quay.io/test/image:latest",
-							},
-						},
-					},
+					ComponentName:  HASCompName,
+					Application:    HASAppName,
+					ContainerImage: "quay.io/test/image:latest",
 				},
 			}
 			Expect(k8sClient.Create(ctx, component)).Should(Succeed())
@@ -280,18 +274,16 @@ var _ = Describe("Component initial build controller", func() {
 					Namespace: HASAppNamespace,
 				},
 				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName: HASCompName,
-					Application:   HASAppName,
-					Secret:        GitSecretName,
+					ComponentName:  HASCompName,
+					Application:    HASAppName,
+					Secret:         GitSecretName,
+					ContainerImage: "docker.io/foo/customized:default-test-component",
 					Source: appstudiov1alpha1.ComponentSource{
 						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 							GitSource: &appstudiov1alpha1.GitSource{
 								URL: SampleRepoLink,
 							},
 						},
-					},
-					Build: appstudiov1alpha1.Build{
-						ContainerImage: "docker.io/foo/customized:default-test-component",
 					},
 				},
 			}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed
+	github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e
 	github.com/tektoncd/pipeline v0.33.0
 	github.com/tektoncd/triggers v0.19.1
 	k8s.io/api v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -1797,10 +1797,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-service v0.0.0-20220429161414-fd5f11553e0f h1:+O6nY2rWbYMM8ak3f8UCoGQn9ULDbhB+WzNifJ/bi34=
-github.com/redhat-appstudio/application-service v0.0.0-20220429161414-fd5f11553e0f/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
-github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed h1:pImL7M8vIDPHGzA3dXW4Cqbb1XtvQQUN3wkFB+Iut98=
-github.com/redhat-appstudio/application-service v0.0.0-20220504153308-f3507a2f91ed/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
+github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e h1:Vx7tzbgpkwr2vyLoAhPi7Qrv/Pul1b4z7i4cNqhkMuo=
+github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.4.3/go.mod h1:hzWm/OOlLXmtF8Qwox3GZlfGJAjVM7KaRkbBjmYAI9k=
 github.com/redhat-developer/alizer/go v0.0.0-20220215154256-33df7feef4ae h1:N2wsIYtziHQ51GNcJY5YcB0YldpR5BwPoTvby+l0vy8=


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

This PR fixes the pipeline build on image source.
Since `spec.source.imageSource` has been removed, if `spec.source.git` is not defined, the `spec.containerImage` is treated as the `imageSource`. If `spec.source.git` is defined, the `spec.containerImage` is treated as the build image. 