### PR TITLE
Add new component image controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,11 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - tekton.dev
   resources:
   - pipelineruns

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - appstudio.redhat.com
   resources:
   - components

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,33 @@ rules:
   - ""
   resources:
   - configmaps
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/status
   verbs:
   - get
   - list

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Component initial build controller", func() {
 		}, 30)
 
 		_ = AfterEach(func() {
-			deleteComponentInitialPipelienRuns(resourceKey)
+			deleteComponentInitialPipelineRuns(resourceKey)
 			deleteComponent(resourceKey)
 		}, 30)
 
@@ -189,7 +189,7 @@ var _ = Describe("Component initial build controller", func() {
 			}
 
 			// Clean up
-			deleteComponentInitialPipelienRuns(resourceKey)
+			deleteComponentInitialPipelineRuns(resourceKey)
 			deleteComponent(resourceKey)
 		})
 	})

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -17,169 +17,16 @@ limitations under the License.
 package controllers
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/prepare"
 	//+kubebuilder:scaffold:imports
 )
-
-const (
-	timeout  = time.Second * 15
-	interval = time.Millisecond * 250
-)
-
-const (
-	HASAppName      = "test-application"
-	HASCompName     = "test-component"
-	HASAppNamespace = "default"
-	SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-	GitSecretName   = "git-secret"
-)
-
-func isOwnedBy(resource []metav1.OwnerReference, component appstudiov1alpha1.Component) bool {
-	if len(resource) == 0 {
-		return false
-	}
-	if resource[0].Kind == "Component" &&
-		resource[0].APIVersion == "appstudio.redhat.com/v1alpha1" &&
-		resource[0].Name == component.Name {
-		return true
-	}
-	return false
-}
-
-// createComponent creates sample component resource and verifies it was properly created
-func createComponent(componentLookupKey types.NamespacedName) {
-	component := &appstudiov1alpha1.Component{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "appstudio.redhat.com/v1alpha1",
-			Kind:       "Component",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      HASCompName,
-			Namespace: HASAppNamespace,
-		},
-		Spec: appstudiov1alpha1.ComponentSpec{
-			ComponentName:  HASCompName,
-			Application:    HASAppName,
-			ContainerImage: "registry.io/user/image:tag",
-			Source: appstudiov1alpha1.ComponentSource{
-				ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-					GitSource: &appstudiov1alpha1.GitSource{
-						URL: SampleRepoLink,
-					},
-				},
-			},
-		},
-	}
-	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-
-	getComponent(componentLookupKey)
-}
-
-func createConfigMap(name string, namespace string, data map[string]string) {
-	configMap := corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		Data: data,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-
-	Expect(k8sClient.Create(ctx, &configMap)).Should(Succeed())
-}
-
-func getComponent(componentLookupKey types.NamespacedName) *appstudiov1alpha1.Component {
-	component := &appstudiov1alpha1.Component{}
-	Eventually(func() bool {
-		k8sClient.Get(ctx, componentLookupKey, component)
-		return component.ResourceVersion != ""
-	}, timeout, interval).Should(BeTrue())
-	return component
-}
-
-func setComponentDevfileModel(componentLookupKey types.NamespacedName) {
-	component := &appstudiov1alpha1.Component{}
-	Eventually(func() error {
-		k8sClient.Get(ctx, componentLookupKey, component)
-		component.Status.Devfile = "version: 2.2.0"
-		return k8sClient.Status().Update(ctx, component)
-	}, timeout, interval).Should(Succeed())
-
-	component = getComponent(componentLookupKey)
-	Expect(component.Status.Devfile).Should(Not(Equal("")))
-}
-
-// deleteComponent deletes the specified component resource and verifies it was properly deleted
-func deleteComponent(componentLookupKey types.NamespacedName) {
-	// Delete
-	Eventually(func() error {
-		f := &appstudiov1alpha1.Component{}
-		k8sClient.Get(ctx, componentLookupKey, f)
-		return k8sClient.Delete(ctx, f)
-	}, timeout, interval).Should(Succeed())
-
-	// Wait for delete to finish
-	Eventually(func() error {
-		f := &appstudiov1alpha1.Component{}
-		return k8sClient.Get(ctx, componentLookupKey, f)
-	}, timeout, interval).ShouldNot(Succeed())
-}
-
-func listComponentPipelienRuns(componentLookupKey types.NamespacedName) *tektonapi.PipelineRunList {
-	pipelineRuns := &tektonapi.PipelineRunList{}
-	labelSelectors := client.ListOptions{Raw: &metav1.ListOptions{
-		LabelSelector: "build.appstudio.openshift.io/component=" + componentLookupKey.Name,
-	}}
-	err := k8sClient.List(ctx, pipelineRuns, &labelSelectors)
-	Expect(err).ToNot(HaveOccurred())
-	return pipelineRuns
-}
-
-func deleteComponentPipelienRuns(componentLookupKey types.NamespacedName) {
-	for _, pipelineRun := range listComponentPipelienRuns(componentLookupKey).Items {
-		Expect(k8sClient.Delete(ctx, &pipelineRun)).Should(Succeed())
-	}
-}
-
-func ensureOnePipelineRunCreated(componentLookupKey types.NamespacedName) {
-	component := getComponent(componentLookupKey)
-	Eventually(func() bool {
-		pipelineRuns := listComponentPipelienRuns(componentLookupKey).Items
-		if len(pipelineRuns) != 1 {
-			return false
-		}
-		pipelineRun := pipelineRuns[0]
-		return isOwnedBy(pipelineRun.OwnerReferences, *component)
-	}, timeout, interval).Should(BeTrue())
-}
-
-func ensureNoPipelineRunsCreated(componentLookupKey types.NamespacedName) {
-	component := getComponent(componentLookupKey)
-
-	pipelineRuns := &tektonapi.PipelineRunList{}
-	Consistently(func() bool {
-		labelSelectors := client.ListOptions{Raw: &metav1.ListOptions{
-			LabelSelector: "build.appstudio.openshift.io/component=" + component.Name,
-		}}
-		k8sClient.List(ctx, pipelineRuns, &labelSelectors)
-		return len(pipelineRuns.Items) == 0
-	}, timeout, interval).WithTimeout(10 * time.Second).Should(BeTrue())
-}
 
 var _ = Describe("Component initial build controller", func() {
 
@@ -195,18 +42,18 @@ var _ = Describe("Component initial build controller", func() {
 		}, 30)
 
 		_ = AfterEach(func() {
-			deleteComponentPipelienRuns(resourceKey)
+			deleteComponentInitialPipelienRuns(resourceKey)
 			deleteComponent(resourceKey)
 		}, 30)
 
 		It("should submit initial build", func() {
 			setComponentDevfileModel(resourceKey)
 
-			ensureOnePipelineRunCreated(resourceKey)
+			ensureOneInitialPipelineRunCreated(resourceKey)
 		})
 
 		It("should not submit initial build if the component devfile model is not set", func() {
-			ensureNoPipelineRunsCreated(resourceKey)
+			ensureNoInitialPipelineRunsCreated(resourceKey)
 		})
 
 		It("should not submit initial build if initial build annotation exists on the component", func() {
@@ -217,7 +64,7 @@ var _ = Describe("Component initial build controller", func() {
 
 			setComponentDevfileModel(resourceKey)
 
-			ensureNoPipelineRunsCreated(resourceKey)
+			ensureNoInitialPipelineRunsCreated(resourceKey)
 		})
 
 		It("should not submit initial build if a container image source is specified in component", func() {
@@ -242,7 +89,7 @@ var _ = Describe("Component initial build controller", func() {
 
 			setComponentDevfileModel(resourceKey)
 
-			ensureNoPipelineRunsCreated(resourceKey)
+			ensureNoInitialPipelineRunsCreated(resourceKey)
 		})
 	})
 
@@ -293,7 +140,7 @@ var _ = Describe("Component initial build controller", func() {
 			setComponentDevfileModel(resourceKey)
 
 			// Wait until all resources created
-			ensureOnePipelineRunCreated(resourceKey)
+			ensureOneInitialPipelineRunCreated(resourceKey)
 
 			// Check that git credentials secret is annotated
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: GitSecretName, Namespace: HASAppNamespace}, gitSecret)).Should(Succeed())
@@ -314,7 +161,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(secretFound).To(BeTrue())
 
 			// Check the pipeline run and its resources
-			pipelineRuns := listComponentPipelienRuns(resourceKey)
+			pipelineRuns := listComponentInitialPipelineRuns(resourceKey)
 			Expect(len(pipelineRuns.Items)).To(Equal(1))
 			pipelineRun := pipelineRuns.Items[0]
 
@@ -342,7 +189,7 @@ var _ = Describe("Component initial build controller", func() {
 			}
 
 			// Clean up
-			deleteComponentPipelienRuns(resourceKey)
+			deleteComponentInitialPipelienRuns(resourceKey)
 			deleteComponent(resourceKey)
 		})
 	})

--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -84,6 +84,12 @@ func (r *NewComponentImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false
 				}
 
+				// Ensure the PipelineRun belongs to a Component
+				if new.ObjectMeta.Annotations[ComponentAnnotationName] == "" && new.ObjectMeta.Labels[ComponentAnnotationName] == "" {
+					// PipelineRun does not belong to a Component
+					return false
+				}
+
 				// Ensure the build is successful
 				buildSuccessful := false
 				for _, c := range new.Status.Conditions {

--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+const (
+	ComponentTaskLabelName = "build.appstudio.openshift.io/component"
+	BuildTaskName          = "build-container"
+)
+
+// NewComponentImageReconciler reconciles a Frigate object
+type NewComponentImageReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Log    logr.Logger
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NewComponentImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&tektonapi.PipelineRun{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return false
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				// React only if pipeline build has just finished successfully and a new image is ready
+
+				var old *tektonapi.PipelineRun
+				var new *tektonapi.PipelineRun
+				old, ok := e.ObjectOld.(*tektonapi.PipelineRun)
+				if !ok {
+					return false
+				}
+				new, ok = e.ObjectNew.(*tektonapi.PipelineRun)
+				if !ok {
+					return false
+				}
+
+				if new.Status.CompletionTime == nil || new.Status.CompletionTime.IsZero() {
+					// Pipeline run is still in progress
+					return false
+				}
+
+				if old.Status.CompletionTime != nil {
+					// Build had been finished before this update
+					return false
+				}
+
+				// Ensure the build is successful
+				buildSuccessful := false
+				for _, c := range new.Status.Conditions {
+					if c.Type == apis.ConditionSucceeded && c.Status == "True" {
+						buildSuccessful = true
+						break
+					}
+				}
+				if !buildSuccessful {
+					return false
+				}
+
+				// Ensure the build used to be in progress
+				buildWasInProgress := false
+				for _, c := range old.Status.Conditions {
+					if c.Type == apis.ConditionSucceeded && c.Reason == "Running" {
+						buildWasInProgress = true
+						break
+					}
+				}
+				return buildWasInProgress
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		})).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns,verbs=get;list;watch
+//+kubebuilder:rbac:groups=tekton.dev,resources=taskruns/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
+func (r *NewComponentImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("NewComponentImage", req.NamespacedName)
+
+	// Fetch the PipelineRun
+	var pipelineRun tektonapi.PipelineRun
+	err := r.Client.Get(ctx, req.NamespacedName, &pipelineRun)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// PipelineRun has been deleted, nothing to do.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	owners := pipelineRun.GetOwnerReferences()
+	if len(owners) == 0 {
+		log.Info(fmt.Sprintf("PipelineRun '%v' has no owner reference", req.NamespacedName))
+		return ctrl.Result{}, nil
+	}
+	owner := owners[0]
+
+	// Get associated Component
+	var component appstudiov1alpha1.Component
+	componentKey := types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      owner.Name,
+	}
+	err = r.Client.Get(ctx, componentKey, &component)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Component has been deleted, nothing to do.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	// Obtain newly built image
+
+	// Search for build TaskRun
+	componentTaskRunRequirement, err := labels.NewRequirement(ComponentTaskLabelName, selection.Equals, []string{component.Name})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	componentTaskRunSelector := labels.NewSelector().Add(*componentTaskRunRequirement)
+	var tasks tektonapi.TaskRunList
+	if err := r.Client.List(ctx, &tasks, &client.ListOptions{LabelSelector: componentTaskRunSelector}); err != nil {
+		return ctrl.Result{}, err
+	}
+	var taskrun *tektonapi.TaskRun
+	for _, tr := range tasks.Items {
+		if strings.Contains(tr.Name, BuildTaskName) {
+			taskrun = &tr
+			break
+		}
+	}
+	if taskrun == nil {
+		// Build task not found, shouldn't happen
+		err := fmt.Errorf("failed to find build TaskRun for %v pipeline", req.NamespacedName)
+		log.Info(err.Error())
+		return ctrl.Result{}, err
+	}
+
+	imageReference := ""
+	for _, taskRunResult := range taskrun.Status.TaskRunResults {
+		if taskRunResult.Name == "IMAGE_URL" {
+			imageReference = taskRunResult.Value
+			break
+		}
+	}
+	if imageReference == "" {
+		err := fmt.Errorf("failed to find build image parameter in TaskRun for %v pipeline", req.NamespacedName)
+		log.Info(err.Error())
+		return ctrl.Result{}, err
+	}
+
+	// Update the image reference in the component
+	if component.Spec.Build.ContainerImage != imageReference {
+		component.Spec.Build.ContainerImage = imageReference
+		if err := r.Client.Update(ctx, &component); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -128,10 +128,10 @@ var _ = Describe("New Component Image Controller", func() {
 			pipelineRun := &tektonapi.PipelineRun{}
 			Expect(k8sClient.Get(ctx, resourceKey, pipelineRun)).Should(Succeed())
 			if pipelineRun.Annotations != nil {
-				delete(pipelineRun.Annotations, ComponentAnnotationName)
+				delete(pipelineRun.Annotations, ComponentNameLabelName)
 			}
 			if pipelineRun.Labels != nil {
-				delete(pipelineRun.Labels, ComponentAnnotationName)
+				delete(pipelineRun.Labels, ComponentNameLabelName)
 			}
 			Expect(k8sClient.Update(ctx, pipelineRun)).Should(Succeed())
 

--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -52,10 +52,10 @@ var _ = Describe("New Component Image Controller", func() {
 				Namespace: HASAppNamespace,
 			}
 			createBuildTaskRunWithImage(initialBuildPipelineKey, ComponentContainerImage)
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			component := getComponent(resourceKey)
-			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+			Expect(component.Spec.ContainerImage).To(Equal(ComponentContainerImage))
 		})
 
 		It("Should update component image after initial build if the image was changed", func() {
@@ -67,11 +67,11 @@ var _ = Describe("New Component Image Controller", func() {
 				Namespace: HASAppNamespace,
 			}
 			createBuildTaskRunWithImage(initialBuildPipelineKey, newImage)
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			Eventually(func() bool {
 				component := getComponent(resourceKey)
-				return component.Spec.Build.ContainerImage == newImage
+				return component.Spec.ContainerImage == newImage
 			}, timeout, interval).Should(BeTrue())
 		})
 
@@ -84,7 +84,7 @@ var _ = Describe("New Component Image Controller", func() {
 				Namespace: HASAppNamespace,
 			}
 			createBuildTaskRunWithImage(initialBuildPipelineKey, ComponentContainerImage+"-initial")
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			createWebhookPipelineRun(resourceKey)
 			createBuildTaskRunWithImage(resourceKey, newImage)
@@ -92,36 +92,36 @@ var _ = Describe("New Component Image Controller", func() {
 
 			Eventually(func() bool {
 				component := getComponent(resourceKey)
-				return component.Spec.Build.ContainerImage == newImage
+				return component.Spec.ContainerImage == newImage
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("Should not update component image after webhook build if new image build was skipped", func() {
 			ensureOneInitialPipelineRunCreated(resourceKey)
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			createWebhookPipelineRun(resourceKey)
 			succeedWebhookPipelineRun(resourceKey)
 
 			component := getComponent(resourceKey)
-			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+			Expect(component.Spec.ContainerImage).To(Equal(ComponentContainerImage))
 		})
 
 		It("Should not update component image after failed build", func() {
 			ensureOneInitialPipelineRunCreated(resourceKey)
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			createWebhookPipelineRun(resourceKey)
 			createBuildTaskRunWithImage(resourceKey, ComponentContainerImage+"-new")
 			failWebhookPipelineRun(resourceKey)
 
 			component := getComponent(resourceKey)
-			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+			Expect(component.Spec.ContainerImage).To(Equal(ComponentContainerImage))
 		})
 
 		It("Should not do anything if PipelineRun doesn't belong to any component", func() {
 			ensureOneInitialPipelineRunCreated(resourceKey)
-			succeedInitialPipelienRun(resourceKey)
+			succeedInitialPipelineRun(resourceKey)
 
 			createWebhookPipelineRun(resourceKey)
 			// Delete relation to the Component
@@ -139,7 +139,7 @@ var _ = Describe("New Component Image Controller", func() {
 			succeedWebhookPipelineRun(resourceKey)
 
 			component := getComponent(resourceKey)
-			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+			Expect(component.Spec.ContainerImage).To(Equal(ComponentContainerImage))
 		})
 	})
 })

--- a/controllers/component_image_controller_test.go
+++ b/controllers/component_image_controller_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	//+kubebuilder:scaffold:imports
+)
+
+var _ = Describe("New Component Image Controller", func() {
+
+	var (
+		// All related to the component resources have the same key (but different type)
+		resourceKey = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+	)
+
+	Context("Test component image update", func() {
+
+		_ = BeforeEach(func() {
+			createComponent(resourceKey)
+			setComponentDevfileModel(resourceKey)
+		}, 30)
+
+		_ = AfterEach(func() {
+			deleteComponent(resourceKey)
+			deleteAllTaskRuns()
+			deleteAllPipelineRuns()
+		}, 30)
+
+		It("Should not update component image after initial build if image reference is the same", func() {
+			ensureOneInitialPipelineRunCreated(resourceKey)
+			initialBuildPipelineKey := types.NamespacedName{
+				Name:      listComponentInitialPipelineRuns(resourceKey).Items[0].Name,
+				Namespace: HASAppNamespace,
+			}
+			createBuildTaskRunWithImage(initialBuildPipelineKey, ComponentContainerImage)
+			succeedInitialPipelienRun(resourceKey)
+
+			component := getComponent(resourceKey)
+			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+		})
+
+		It("Should update component image after initial build if the image was changed", func() {
+			newImage := ComponentContainerImage + "-initial1234"
+
+			ensureOneInitialPipelineRunCreated(resourceKey)
+			initialBuildPipelineKey := types.NamespacedName{
+				Name:      listComponentInitialPipelineRuns(resourceKey).Items[0].Name,
+				Namespace: HASAppNamespace,
+			}
+			createBuildTaskRunWithImage(initialBuildPipelineKey, newImage)
+			succeedInitialPipelienRun(resourceKey)
+
+			Eventually(func() bool {
+				component := getComponent(resourceKey)
+				return component.Spec.Build.ContainerImage == newImage
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should update component image after webhook build", func() {
+			newImage := ComponentContainerImage + "-commit1234"
+
+			ensureOneInitialPipelineRunCreated(resourceKey)
+			initialBuildPipelineKey := types.NamespacedName{
+				Name:      listComponentInitialPipelineRuns(resourceKey).Items[0].Name,
+				Namespace: HASAppNamespace,
+			}
+			createBuildTaskRunWithImage(initialBuildPipelineKey, ComponentContainerImage+"-initial")
+			succeedInitialPipelienRun(resourceKey)
+
+			createWebhookPipelineRun(resourceKey)
+			createBuildTaskRunWithImage(resourceKey, newImage)
+			succeedWebhookPipelineRun(resourceKey)
+
+			Eventually(func() bool {
+				component := getComponent(resourceKey)
+				return component.Spec.Build.ContainerImage == newImage
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should not update component image after webhook build if new image build was skipped", func() {
+			ensureOneInitialPipelineRunCreated(resourceKey)
+			succeedInitialPipelienRun(resourceKey)
+
+			createWebhookPipelineRun(resourceKey)
+			succeedWebhookPipelineRun(resourceKey)
+
+			component := getComponent(resourceKey)
+			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+		})
+
+		It("Should not update component image after failed build", func() {
+			ensureOneInitialPipelineRunCreated(resourceKey)
+			succeedInitialPipelienRun(resourceKey)
+
+			createWebhookPipelineRun(resourceKey)
+			createBuildTaskRunWithImage(resourceKey, "newImage")
+			failWebhookPipelineRun(resourceKey)
+
+			component := getComponent(resourceKey)
+			Expect(component.Spec.Build.ContainerImage).To(Equal(ComponentContainerImage))
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -114,6 +114,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&NewComponentImageReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("NewComponentImage"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -114,10 +114,11 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&NewComponentImageReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NewComponentImage"),
+	err = (&ComponentImageReconciler{
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("ComponentImage"),
+		EventRecorder: k8sManager.GetEventRecorderFor("ComponentImage"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -170,8 +170,8 @@ func createWebhookPipelineRun(resourceKey types.NamespacedName) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resourceKey.Name,
 			Namespace: resourceKey.Namespace,
-			Annotations: map[string]string{
-				ComponentAnnotationName: resourceKey.Name,
+			Labels: map[string]string{
+				ComponentNameLabelName: resourceKey.Name,
 			},
 		},
 	}

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -70,17 +70,15 @@ func createComponent(componentLookupKey types.NamespacedName) {
 			Namespace: HASAppNamespace,
 		},
 		Spec: appstudiov1alpha1.ComponentSpec{
-			ComponentName: HASCompName,
-			Application:   HASAppName,
+			ComponentName:  HASCompName,
+			Application:    HASAppName,
+			ContainerImage: ComponentContainerImage,
 			Source: appstudiov1alpha1.ComponentSource{
 				ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
 					GitSource: &appstudiov1alpha1.GitSource{
 						URL: SampleRepoLink,
 					},
 				},
-			},
-			Build: appstudiov1alpha1.Build{
-				ContainerImage: ComponentContainerImage,
 			},
 		},
 	}
@@ -136,7 +134,7 @@ func listComponentInitialPipelineRuns(componentKey types.NamespacedName) *tekton
 	return pipelineRuns
 }
 
-func deleteComponentInitialPipelienRuns(componentKey types.NamespacedName) {
+func deleteComponentInitialPipelineRuns(componentKey types.NamespacedName) {
 	for _, pipelineRun := range listComponentInitialPipelineRuns(componentKey).Items {
 		Expect(k8sClient.Delete(ctx, &pipelineRun)).Should(Succeed())
 	}
@@ -227,7 +225,7 @@ func failWebhookPipelineRun(resourceKey types.NamespacedName) {
 	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
 }
 
-func succeedInitialPipelienRun(componentKey types.NamespacedName) {
+func succeedInitialPipelineRun(componentKey types.NamespacedName) {
 	// Put the PipelineRun in runnning state
 	pipelineRun := &listComponentInitialPipelineRuns(componentKey).Items[0]
 	pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now()}

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+)
+
+const (
+	timeout  = time.Second * 15
+	interval = time.Millisecond * 250
+)
+
+const (
+	HASAppName              = "test-application"
+	HASCompName             = "test-component"
+	HASAppNamespace         = "default"
+	SampleRepoLink          = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+	GitSecretName           = "git-secret"
+	ComponentContainerImage = "registry.io/username/image:tag"
+)
+
+func isOwnedBy(resource []metav1.OwnerReference, component appstudiov1alpha1.Component) bool {
+	if len(resource) == 0 {
+		return false
+	}
+	if resource[0].Kind == "Component" &&
+		resource[0].APIVersion == "appstudio.redhat.com/v1alpha1" &&
+		resource[0].Name == component.Name {
+		return true
+	}
+	return false
+}
+
+// createComponent creates sample component resource and verifies it was properly created
+func createComponent(componentLookupKey types.NamespacedName) {
+	component := &appstudiov1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "appstudio.redhat.com/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      HASCompName,
+			Namespace: HASAppNamespace,
+		},
+		Spec: appstudiov1alpha1.ComponentSpec{
+			ComponentName: HASCompName,
+			Application:   HASAppName,
+			Source: appstudiov1alpha1.ComponentSource{
+				ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+					GitSource: &appstudiov1alpha1.GitSource{
+						URL: SampleRepoLink,
+					},
+				},
+			},
+			Build: appstudiov1alpha1.Build{
+				ContainerImage: ComponentContainerImage,
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
+
+	getComponent(componentLookupKey)
+}
+
+func getComponent(componentKey types.NamespacedName) *appstudiov1alpha1.Component {
+	component := &appstudiov1alpha1.Component{}
+	Eventually(func() bool {
+		k8sClient.Get(ctx, componentKey, component)
+		return component.ResourceVersion != ""
+	}, timeout, interval).Should(BeTrue())
+	return component
+}
+
+// deleteComponent deletes the specified component resource and verifies it was properly deleted
+func deleteComponent(componentKey types.NamespacedName) {
+	// Delete
+	Eventually(func() error {
+		f := &appstudiov1alpha1.Component{}
+		k8sClient.Get(ctx, componentKey, f)
+		return k8sClient.Delete(ctx, f)
+	}, timeout, interval).Should(Succeed())
+
+	// Wait for delete to finish
+	Eventually(func() error {
+		f := &appstudiov1alpha1.Component{}
+		return k8sClient.Get(ctx, componentKey, f)
+	}, timeout, interval).ShouldNot(Succeed())
+}
+
+func setComponentDevfileModel(componentKey types.NamespacedName) {
+	component := &appstudiov1alpha1.Component{}
+	Eventually(func() error {
+		k8sClient.Get(ctx, componentKey, component)
+		component.Status.Devfile = "version: 2.2.0"
+		return k8sClient.Status().Update(ctx, component)
+	}, timeout, interval).Should(Succeed())
+
+	component = getComponent(componentKey)
+	Expect(component.Status.Devfile).Should(Not(Equal("")))
+}
+
+func listComponentInitialPipelineRuns(componentKey types.NamespacedName) *tektonapi.PipelineRunList {
+	pipelineRuns := &tektonapi.PipelineRunList{}
+	labelSelectors := client.ListOptions{Raw: &metav1.ListOptions{
+		LabelSelector: "build.appstudio.openshift.io/component=" + componentKey.Name,
+	}}
+	err := k8sClient.List(ctx, pipelineRuns, &labelSelectors)
+	Expect(err).ToNot(HaveOccurred())
+	return pipelineRuns
+}
+
+func deleteComponentInitialPipelienRuns(componentKey types.NamespacedName) {
+	for _, pipelineRun := range listComponentInitialPipelineRuns(componentKey).Items {
+		Expect(k8sClient.Delete(ctx, &pipelineRun)).Should(Succeed())
+	}
+}
+
+func ensureOneInitialPipelineRunCreated(componentKey types.NamespacedName) {
+	component := getComponent(componentKey)
+	Eventually(func() bool {
+		pipelineRuns := listComponentInitialPipelineRuns(componentKey).Items
+		if len(pipelineRuns) != 1 {
+			return false
+		}
+		pipelineRun := pipelineRuns[0]
+		return isOwnedBy(pipelineRun.OwnerReferences, *component)
+	}, timeout, interval).Should(BeTrue())
+}
+
+func ensureNoInitialPipelineRunsCreated(componentLookupKey types.NamespacedName) {
+	component := getComponent(componentLookupKey)
+
+	pipelineRuns := &tektonapi.PipelineRunList{}
+	Consistently(func() bool {
+		labelSelectors := client.ListOptions{Raw: &metav1.ListOptions{
+			LabelSelector: "build.appstudio.openshift.io/component=" + component.Name,
+		}}
+		k8sClient.List(ctx, pipelineRuns, &labelSelectors)
+		return len(pipelineRuns.Items) == 0
+	}, timeout, interval).WithTimeout(10 * time.Second).Should(BeTrue())
+}
+
+func createWebhookPipelineRun(resourceKey types.NamespacedName) {
+	pipelineRun := &tektonapi.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceKey.Name,
+			Namespace: resourceKey.Namespace,
+			Annotations: map[string]string{
+				ComponentAnnotationName: resourceKey.Name,
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pipelineRun)).Should(Succeed())
+
+	Expect(k8sClient.Get(ctx, resourceKey, pipelineRun)).Should(Succeed())
+	pipelineRun.Status = tektonapi.PipelineRunStatus{
+		Status: v1beta1.Status{
+			Conditions: v1beta1.Conditions{
+				apis.Condition{
+					Reason: "Running",
+					Status: "Unknown",
+					Type:   apis.ConditionSucceeded,
+				},
+			},
+		},
+		PipelineRunStatusFields: tektonapi.PipelineRunStatusFields{
+			StartTime: &metav1.Time{
+				Time: time.Now(),
+			},
+		},
+	}
+	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
+}
+
+func succeedWebhookPipelineRun(resourceKey types.NamespacedName) {
+	pipelineRun := &tektonapi.PipelineRun{}
+	Expect(k8sClient.Get(ctx, resourceKey, pipelineRun)).Should(Succeed())
+	pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	pipelineRun.Status.Conditions = v1beta1.Conditions{
+		apis.Condition{
+			Reason: "Completed",
+			Status: "True",
+			Type:   apis.ConditionSucceeded,
+		},
+	}
+	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
+}
+
+func failWebhookPipelineRun(resourceKey types.NamespacedName) {
+	pipelineRun := &tektonapi.PipelineRun{}
+	Expect(k8sClient.Get(ctx, resourceKey, pipelineRun)).Should(Succeed())
+	pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	pipelineRun.Status.Conditions = v1beta1.Conditions{
+		apis.Condition{
+			Reason: "Failed",
+			Status: "False",
+			Type:   apis.ConditionSucceeded,
+		},
+	}
+	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
+}
+
+func succeedInitialPipelienRun(componentKey types.NamespacedName) {
+	// Put the PipelineRun in runnning state
+	pipelineRun := &listComponentInitialPipelineRuns(componentKey).Items[0]
+	pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now()}
+	pipelineRun.Status.Conditions = v1beta1.Conditions{
+		apis.Condition{
+			Reason: "Running",
+			Status: "Unknown",
+			Type:   apis.ConditionSucceeded,
+		}}
+	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
+
+	// Succeed the PipelineRun
+	pipelineRun = &listComponentInitialPipelineRuns(componentKey).Items[0]
+	pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	pipelineRun.Status.Conditions = v1beta1.Conditions{
+		apis.Condition{
+			Reason: "Completed",
+			Status: "True",
+			Type:   apis.ConditionSucceeded,
+		},
+	}
+	Expect(k8sClient.Status().Update(ctx, pipelineRun)).Should(Succeed())
+}
+
+func deleteAllPipelineRuns() {
+	k8sClient.DeleteAllOf(ctx, &tektonapi.PipelineRun{}, &client.DeleteAllOfOptions{
+		ListOptions: client.ListOptions{Namespace: HASAppNamespace},
+	})
+}
+
+func createBuildTaskRunWithImage(resourceKey types.NamespacedName, image string) {
+	taskRunKey := types.NamespacedName{
+		Name:      resourceKey.Name + "-" + BuildImageTaskName + "-random1234",
+		Namespace: resourceKey.Namespace,
+	}
+
+	taskRun := &tektonapi.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      taskRunKey.Name,
+			Namespace: taskRunKey.Namespace,
+			Labels: map[string]string{
+				PipelineRunLabelName:  resourceKey.Name,
+				PipelineTaskLabelName: BuildImageTaskName,
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, taskRun)).Should(Succeed())
+
+	Expect(k8sClient.Get(ctx, taskRunKey, taskRun)).Should(Succeed())
+	taskRun.Status = tektonapi.TaskRunStatus{
+		TaskRunStatusFields: tektonapi.TaskRunStatusFields{
+			TaskRunResults: []tektonapi.TaskRunResult{
+				{
+					Name:  "IMAGE_DIGEST",
+					Value: "sha256:71fd928246979eb68fbe12ee60159408f7535f6252335a4d13497e35eb81854f",
+				},
+				{
+					Name:  "IMAGE_URL",
+					Value: image,
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Status().Update(ctx, taskRun)).Should(Succeed())
+}
+
+func deleteAllTaskRuns() {
+	k8sClient.DeleteAllOf(ctx, &tektonapi.TaskRun{}, &client.DeleteAllOfOptions{
+		ListOptions: client.ListOptions{Namespace: HASAppNamespace},
+	})
+}
+
+func createConfigMap(name string, namespace string, data map[string]string) {
+	configMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		Data: data,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	Expect(k8sClient.Create(ctx, &configMap)).Should(Succeed())
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.0
+	knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006
 	sigs.k8s.io/controller-runtime v0.11.0
 )
 
@@ -142,7 +143,6 @@ require (
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220114203427-a0453230fd26 // indirect
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 // indirect
-	knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006 // indirect
 	oras.land/oras-go v0.4.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/main.go
+++ b/main.go
@@ -107,12 +107,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.NewComponentImageReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("NewComponentImage"),
+	if err = (&controllers.ComponentImageReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("ComponentImage"),
+		EventRecorder: mgr.GetEventRecorderFor("ComponentImage"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "NewComponentImage")
+		setupLog.Error(err, "unable to create controller", "controller", "ComponentImage")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/main.go
+++ b/main.go
@@ -106,6 +106,15 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ComponentInitialBuild")
 		os.Exit(1)
 	}
+
+	if err = (&controllers.NewComponentImageReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("NewComponentImage"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NewComponentImage")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 }
 
 func getCacheFunc() (cache.NewCacheFunc, error) {
-	componentPipelineRunRequirement, err := labels.NewRequirement(controllers.PipelineRunLabelName, selection.Exists, []string{})
+	componentPipelineRunRequirement, err := labels.NewRequirement(controllers.ComponentNameLabelName, selection.Exists, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -24,10 +24,13 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -68,6 +71,22 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	if err := triggersapi.AddToScheme(scheme); err != nil {
+		setupLog.Error(err, "unable to add triggers api to the scheme")
+		os.Exit(1)
+	}
+
+	if err := taskrunapi.AddToScheme(scheme); err != nil {
+		setupLog.Error(err, "unable to add triggers api to the scheme")
+		os.Exit(1)
+	}
+
+	cacheFunction, err := getCacheFunc()
+	if err != nil {
+		setupLog.Error(err, "failed to create cache function")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -75,19 +94,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "5483be8f.redhat.com",
+		NewCache:               cacheFunction,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	if err := triggersapi.AddToScheme(mgr.GetScheme()); err != nil {
-		setupLog.Error(err, "unable to add triggers api to the scheme")
-		os.Exit(1)
-	}
-
-	if err := taskrunapi.AddToScheme(mgr.GetScheme()); err != nil {
-		setupLog.Error(err, "unable to add triggers api to the scheme")
 		os.Exit(1)
 	}
 
@@ -132,4 +142,22 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func getCacheFunc() (cache.NewCacheFunc, error) {
+	componentPipelineRunRequirement, err := labels.NewRequirement(controllers.PipelineRunLabelName, selection.Exists, []string{})
+	if err != nil {
+		return nil, err
+	}
+	appStudioComponentPipelineRunSelector := labels.NewSelector().Add(*componentPipelineRunRequirement)
+
+	selectors := cache.SelectorsByObject{
+		&taskrunapi.PipelineRun{}: {
+			Label: appStudioComponentPipelineRunSelector,
+		},
+	}
+
+	return cache.BuilderWithOptions(cache.Options{
+		SelectorsByObject: selectors,
+	}), nil
 }


### PR DESCRIPTION
#### What does this MR do?

This MR introduces a new controller that watches all Component related PipelineRuns and if any finish successfully, then checks for a newly built component image and updates corresponding component configuration.

#### How to test this MR?

1. Create an Application
2. Create a Component of the Application
3. Wait until initial build succeeds
4. Trigger a new build via the Component webhook
5. Wait until the webhook build finishes
6. Check the Component, it should contain the new image under `Spec.Build.ContainerImage`