### PR TITLE
PLNSRVCE-250: bypass mouting of appstudio registry secret as workspace secret volume if secret is not present

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -75,6 +75,7 @@ func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=components/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -313,3 +313,18 @@ func createConfigMap(name string, namespace string, data map[string]string) {
 
 	Expect(k8sClient.Create(ctx, &configMap)).Should(Succeed())
 }
+
+func createSecret(name, namespace string) {
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+
+	}
+	Expect(k8sClient.Create(ctx, &secret)).Should(Succeed())
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	//if you update this you must also update controllers/suite_test.go
-	github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e
+	github.com/redhat-appstudio/application-service v0.0.0-20220525194657-93eb79a48fe1
 	github.com/tektoncd/pipeline v0.33.0
 	github.com/tektoncd/triggers v0.19.1
 	k8s.io/api v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -1797,8 +1797,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e h1:Vx7tzbgpkwr2vyLoAhPi7Qrv/Pul1b4z7i4cNqhkMuo=
-github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
+github.com/redhat-appstudio/application-service v0.0.0-20220525194657-93eb79a48fe1 h1:vgPGDwVkOBkNAPjWaZbDBcVUyPlC8L4jTCtBoaHTpNA=
+github.com/redhat-appstudio/application-service v0.0.0-20220525194657-93eb79a48fe1/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=
 github.com/redhat-appstudio/service-provider-integration-scm-file-retriever v0.4.3/go.mod h1:hzWm/OOlLXmtF8Qwox3GZlfGJAjVM7KaRkbBjmYAI9k=
 github.com/redhat-developer/alizer/go v0.0.0-20220215154256-33df7feef4ae h1:N2wsIYtziHQ51GNcJY5YcB0YldpR5BwPoTvby+l0vy8=


### PR DESCRIPTION
vendor in changes from https://github.com/redhat-appstudio/application-service/pull/116 
establish rbac for secret retrieval
add to in repo e2e tests

follows pattern I now see @brunoapimentel followed with overriding the default tekton bundle

believe the need for this was demonstrated when @psturc tried out the changes from https://github.com/redhat-appstudio/application-service/pull/116 in a test cluster, and we saw the workspace volume still getting declared if the secret is missing

@mmorhun @Michkov @sbose78 fyi / ptal