### PR TITLE
Do not update component's image for HACBS pipeliens

### DIFF
--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -40,10 +40,11 @@ import (
 )
 
 const (
-	ComponentNameLabelName = "build.appstudio.openshift.io/component"
-	PipelineRunLabelName   = "tekton.dev/pipelineRun"
-	PipelineTaskLabelName  = "tekton.dev/pipelineTask"
-	BuildImageTaskName     = "build-container"
+	ComponentNameLabelName        = "build.appstudio.openshift.io/component"
+	PipelineRunLabelName          = "tekton.dev/pipelineRun"
+	PipelineTaskLabelName         = "tekton.dev/pipelineTask"
+	UpdateComponentAnnotationName = "appstudio.redhat.com/updateComponentOnSuccess"
+	BuildImageTaskName            = "build-container"
 )
 
 // ComponentImageReconciler reconciles a Frigate object
@@ -88,6 +89,11 @@ func (r *ComponentImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				// Ensure the PipelineRun belongs to a Component
 				if new.ObjectMeta.Labels == nil || new.ObjectMeta.Labels[ComponentNameLabelName] == "" {
 					// PipelineRun does not belong to a Component
+					return false
+				}
+
+				// Check if the build should be handled by the operator
+				if new.ObjectMeta.Annotations != nil && new.ObjectMeta.Annotations[UpdateComponentAnnotationName] == "false" {
 					return false
 				}
 

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -33,8 +33,13 @@ import (
 )
 
 const (
-	timeout  = time.Second * 15
-	interval = time.Millisecond * 250
+	// timeout is used as a limit until condition become true
+	// Usually used in Eventually statements
+	timeout = time.Second * 15
+	// ensureTimeout is used as a period of time during which the condition should not be changed
+	// Usually used in Consistently statements
+	ensureTimeout = time.Second * 4
+	interval      = time.Millisecond * 250
 )
 
 const (
@@ -162,7 +167,7 @@ func ensureNoInitialPipelineRunsCreated(componentLookupKey types.NamespacedName)
 		}}
 		Expect(k8sClient.List(ctx, pipelineRuns, &labelSelectors)).To(Succeed())
 		return len(pipelineRuns.Items) == 0
-	}, timeout, interval).WithTimeout(10 * time.Second).Should(BeTrue())
+	}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
 }
 
 func createWebhookPipelineRun(resourceKey types.NamespacedName) {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

This PR adds check for `appstudio.redhat.com/updateComponentOnSuccess` annotation in Component's PipelienRuns. If the annotation is set to `false`, then the image of the Component will no be updated in its spec (the update is delegated to HACBS integration operator).

Related PR: https://github.com/redhat-appstudio/build-definitions/pull/118