### PR TITLE
check presence of tekton crds before initializing controller manager

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -133,3 +133,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	k8s.io/api v0.24.2
+	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	knative.dev/pkg v0.0.0-20220524202603-19adf798efb8
@@ -148,7 +149,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect


### PR DESCRIPTION
After analyzing results from https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_jvm-build-service/144/pull-ci-redhat-appstudio-jvm-build-service-main-jvm-build-service-in-repo-e2e/1553029354840133632 and in particluar https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_jvm-build-service/144/pull-ci-redhat-appstudio-jvm-build-service-main-jvm-build-service-in-repo-e2e/1553029354840133632/artifacts/jvm-build-service-in-repo-e2e/gather-extra/artifacts/pods/build-service_build-service-controller-manager-6b4d9565b8-wthpm_manager.log 

```
I0729 15:04:05.852597       1 request.go:601] Waited for 1.019344803s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/samples.operator.openshift.io/v1?timeout=32s
1.659107047555279e+09	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
1.6591070502596347e+09	INFO	setup	starting manager
1.6591070502599032e+09	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
1.6591070502599742e+09	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
I0729 15:04:10.260058       1 leaderelection.go:248] attempting to acquire leader lease build-service/5483be8f.redhat.com...
I0729 15:04:10.270017       1 leaderelection.go:258] successfully acquired lease build-service/5483be8f.redhat.com
1.6591070502700915e+09	DEBUG	events	Normal	{"object": {"kind":"Lease","namespace":"build-service","name":"5483be8f.redhat.com","uid":"58c7399c-76d7-4ccc-bc42-56456bfcfd91","apiVersion":"coordination.k8s.io/v1","resourceVersion":"42595"}, "reason": "LeaderElection", "message": "build-service-controller-manager-6b4d9565b8-wthpm_df5eec08-942f-4005-bcfa-38883a776c43 became leader"}
1.6591070502702658e+09	INFO	Starting EventSource	{"controller": "component", "controllerGroup": "appstudio.redhat.com", "controllerKind": "Component", "source": "kind source: *v1alpha1.Component"}
1.659107050270296e+09	INFO	Starting Controller	{"controller": "component", "controllerGroup": "appstudio.redhat.com", "controllerKind": "Component"}
1.6591070502703881e+09	INFO	Starting EventSource	{"controller": "pipelinerun", "controllerGroup": "tekton.dev", "controllerKind": "PipelineRun", "source": "kind source: *v1beta1.PipelineRun"}
1.659107050270438e+09	INFO	Starting Controller	{"controller": "pipelinerun", "controllerGroup": "tekton.dev", "controllerKind": "PipelineRun"}
1.6591070529735832e+09	ERROR	controller-runtime.source	if kind is a CRD, it should be installed before calling Start	{"kind": "PipelineRun.tekton.dev", "error": "no matches for kind \"PipelineRun\" in version \"tekton.dev/v1beta1\""}
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1.1
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/source/source.go:139
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:233
k8s.io/apimachinery/pkg/util/wait.poll
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:580
k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:545
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/source/source.go:132
```

where that error log repeats a bunch.

Also initiated https://coreos.slack.com/archives/C03KN2B47GU/p1659116350713419 