### PR TITLE
Rework GitHub client to manage PaC PR depending on current state

### DIFF
--- a/pkg/github/github_helper_debug_test.go
+++ b/pkg/github/github_helper_debug_test.go
@@ -43,7 +43,7 @@ func TestCreatePaCPullRequest(t *testing.T) {
 
 	ghclient := NewGithubClient(accessToken)
 
-	pipelineOnPush := []byte("pipelineOnPush:\n  bundle: 'test-bundle-1'\n  when: 'in-push'\n")
+	pipelineOnPush := []byte("pipelineOnPush:\n  bundle: 'test-bundle-1'\n  when: 'on-push'\n")
 	pipelineOnPR := []byte("pipelineOnPR:\n  bundle: 'test-bundle-2'\n  when: 'on-pr'\n")
 
 	componentName := "unittest-component-name"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

This PR adds logic that analyzes current state of the Pipelines as Code configuration in the component repository and updates only needed, if any, parts.
Conditions handled (arbitrary combinations of the below, independent on if the condition true or false):
- configuration is up to date in main branch (no PR is needed)
- branch to create PR from exists
- content of branch to create PR from is up to date
- PR exists

This PR fixes problem with empty or duplicated commits.