### PR TITLE
Implement PaC GitLab integration

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -477,6 +477,14 @@ func ensureSecretCreated(resourceKey types.NamespacedName) {
 	}, timeout, interval).Should(BeTrue())
 }
 
+func ensureSecretNotCreated(resourceKey types.NamespacedName) {
+	secret := &corev1.Secret{}
+	Consistently(func() bool {
+		err := k8sClient.Get(ctx, resourceKey, secret)
+		return errors.IsNotFound(err)
+	}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+}
+
 func createNamespace(name string) {
 	namespace := corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/xanzy/go-gitlab v0.68.2
 	k8s.io/api v0.24.2
 	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.24.2
@@ -86,7 +87,9 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1179,6 +1179,7 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-discover v0.0.0-20210818145131-c573d69da192/go.mod h1:3/4dzY4lR1Hzt9bBqMhBzG7lngZ0GKx/nL6G/ad62wE=
 github.com/hashicorp/go-gatedio v0.5.0/go.mod h1:Lr3t8L6IyxD3DAeaUxGcgl2JnRUpWMCsmBl4Omu/2t4=
@@ -1193,6 +1194,7 @@ github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-hclog v0.16.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.1.0 h1:QsGcniKx5/LuX2eYoeL+Np3UKYPNaN7YKpTh29h8rbw=
 github.com/hashicorp/go-hclog v1.1.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -1220,6 +1222,7 @@ github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
@@ -2176,6 +2179,7 @@ github.com/wavesoftware/go-ensure v1.0.0/go.mod h1:K2UAFSwMTvpiRGay/M3aEYYuurcR8
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/go-gitlab v0.65.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
+github.com/xanzy/go-gitlab v0.68.2 h1:bRVpa+czzpR2j2UV9oeJRU3SO40ieOHlgKlVwW0LRBw=
 github.com/xanzy/go-gitlab v0.68.2/go.mod h1:o4yExCtdaqlM8YGdDJWuZoBmfxBsmA9TPEjs9mx1UO4=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -124,7 +124,7 @@ func (c *GithubClient) filesUpToDate(owner, repository, branch string, files []F
 			Ref: "refs/heads/" + branch,
 		}
 
-		fileContentReader, resp, err := c.client.Repositories.DownloadContents(c.ctx, owner, repository, file.Name, opts)
+		fileContentReader, resp, err := c.client.Repositories.DownloadContents(c.ctx, owner, repository, file.FullPath, opts)
 		if err != nil {
 			// It's not clear when it returns 404 or 200 with the error message. Check both.
 			if resp.StatusCode == 404 || strings.Contains(err.Error(), "no file named") {
@@ -149,7 +149,7 @@ func (c *GithubClient) createTree(owner, repository string, baseRef *github.Refe
 	// Load each file into the tree.
 	entries := []*github.TreeEntry{}
 	for _, file := range files {
-		entries = append(entries, &github.TreeEntry{Path: github.String(file.Name), Type: github.String("blob"), Content: github.String(string(file.Content)), Mode: github.String("100644")})
+		entries = append(entries, &github.TreeEntry{Path: github.String(file.FullPath), Type: github.String("blob"), Content: github.String(string(file.Content)), Mode: github.String("100644")})
 	}
 
 	tree, _, err = c.client.Git.CreateTree(c.ctx, owner, repository, *baseRef.Object.SHA, entries)

--- a/pkg/github/github_helper.go
+++ b/pkg/github/github_helper.go
@@ -36,8 +36,8 @@ var (
 )
 
 type File struct {
-	Name    string
-	Content []byte
+	FullPath string
+	Content  []byte
 }
 
 type PaCPullRequestData struct {

--- a/pkg/github/github_helper_debug_test.go
+++ b/pkg/github/github_helper_debug_test.go
@@ -48,9 +48,8 @@ func TestCreatePaCPullRequest(t *testing.T) {
 
 	componentName := "unittest-component-name"
 	gitSourceUrlParts := strings.Split(repoUrl, "/")
-	owner := gitSourceUrlParts[3]
 	prData := &PaCPullRequestData{
-		Owner:         owner,
+		Owner:         gitSourceUrlParts[3],
 		Repository:    gitSourceUrlParts[4],
 		CommitMessage: "Appstudio update " + componentName,
 		Branch:        "appstudio-" + componentName,
@@ -60,8 +59,8 @@ func TestCreatePaCPullRequest(t *testing.T) {
 		AuthorName:    "redhat-appstudio",
 		AuthorEmail:   "appstudio@redhat.com",
 		Files: []File{
-			{Name: ".tekton/" + componentName + "-push.yaml", Content: pipelineOnPush},
-			{Name: ".tekton/" + componentName + "-pull.yaml", Content: pipelineOnPR},
+			{FullPath: ".tekton/" + componentName + "-push.yaml", Content: pipelineOnPush},
+			{FullPath: ".tekton/" + componentName + "-pull.yaml", Content: pipelineOnPR},
 		},
 	}
 
@@ -106,8 +105,8 @@ func TestCreatePaCPullRequestViaGitHubApplication(t *testing.T) {
 		AuthorName:    "redhat-appstudio",
 		AuthorEmail:   "appstudio@redhat.com",
 		Files: []File{
-			{Name: ".tekton/" + componentName + "-push.yaml", Content: pipelineOnPush},
-			{Name: ".tekton/" + componentName + "-pull.yaml", Content: pipelineOnPR},
+			{FullPath: ".tekton/" + componentName + "-push.yaml", Content: pipelineOnPush},
+			{FullPath: ".tekton/" + componentName + "-pull.yaml", Content: pipelineOnPR},
 		},
 	}
 

--- a/pkg/gitlab/gitlab_client.go
+++ b/pkg/gitlab/gitlab_client.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+// Allow mocking for tests
+var NewGitlabClient func(accessToken string) (*GitlabClient, error) = newGitlabClient
+
+type GitlabClient struct {
+	client *gitlab.Client
+}
+
+func newGitlabClient(accessToken string) (*GitlabClient, error) {
+	glc := &GitlabClient{}
+	c, err := gitlab.NewClient(accessToken)
+	if err != nil {
+		return nil, err
+	}
+	glc.client = c
+
+	return glc, nil
+}
+
+func (c *GitlabClient) branchExist(projectPath, branchName string) (bool, error) {
+	_, resp, err := c.client.Branches.GetBranch(projectPath, branchName)
+	if err != nil {
+		if resp.StatusCode == 404 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (c *GitlabClient) createBranch(projectPath, branchName, baseBranchName string) error {
+	opts := &gitlab.CreateBranchOptions{
+		Branch: &branchName,
+		Ref:    &baseBranchName,
+	}
+	_, _, err := c.client.Branches.CreateBranch(projectPath, opts)
+	return err
+}
+
+func (c *GitlabClient) deleteBranch(projectPath, branchName string) error {
+	_, err := c.client.Branches.DeleteBranch(projectPath, branchName)
+	return err
+}
+
+func (c *GitlabClient) filesUpToDate(projectPath, branchName string, files []File) (bool, error) {
+	for _, file := range files {
+		opts := &gitlab.GetRawFileOptions{
+			Ref: &branchName,
+		}
+		fileContent, resp, err := c.client.RepositoryFiles.GetRawFile(projectPath, file.FullPath, opts)
+		if err != nil {
+			if resp.StatusCode != 404 {
+				return false, err
+			}
+			return false, nil
+		}
+		if !bytes.Equal(fileContent, file.Content) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (c *GitlabClient) commitFilesIntoBranch(projectPath, branchName, commitMessage, authorName, authorEmail string, files []File) error {
+	actions := []*gitlab.CommitActionOptions{}
+	for _, file := range files {
+		filePath := file.FullPath
+		content := string(file.Content)
+		var fileAction gitlab.FileActionValue
+
+		// Detect file action: update or create
+		opts := &gitlab.GetRawFileOptions{Ref: &branchName}
+		_, resp, err := c.client.RepositoryFiles.GetRawFile(projectPath, file.FullPath, opts)
+		if err != nil {
+			if resp.StatusCode != 404 {
+				return err
+			}
+			fileAction = gitlab.FileCreate
+		} else {
+			fileAction = gitlab.FileUpdate
+		}
+
+		action := &gitlab.CommitActionOptions{
+			Action:   &fileAction,
+			FilePath: &filePath,
+			Content:  &content,
+		}
+
+		actions = append(actions, action)
+	}
+
+	opts := &gitlab.CreateCommitOptions{
+		Branch:        &branchName,
+		CommitMessage: &commitMessage,
+		AuthorName:    &authorName,
+		AuthorEmail:   &authorEmail,
+		Actions:       actions,
+	}
+	_, _, err := c.client.Commits.CreateCommit(projectPath, opts)
+	return err
+}
+
+func (c *GitlabClient) diffNotEmpty(projectPath, branchName, baseBranchName string) (bool, error) {
+	straight := false
+	opts := &gitlab.CompareOptions{
+		From:     &baseBranchName,
+		To:       &branchName,
+		Straight: &straight,
+	}
+	cmpres, _, err := c.client.Repositories.Compare(projectPath, opts)
+	if err != nil {
+		return false, err
+	}
+	return len(cmpres.Diffs) > 0, nil
+}
+
+func (c *GitlabClient) findMergeRequestByBranches(projectPath, branch, targetBranch string) (*gitlab.MergeRequest, error) {
+	openedState := "opened"
+	viewType := "simple"
+	opts := &gitlab.ListProjectMergeRequestsOptions{
+		State:        &openedState,
+		SourceBranch: &branch,
+		TargetBranch: &targetBranch,
+		View:         &viewType,
+	}
+	mrs, _, err := c.client.MergeRequests.ListProjectMergeRequests(projectPath, opts)
+	if err != nil {
+		return nil, err
+	}
+	switch len(mrs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return mrs[0], nil
+	default:
+		return nil, fmt.Errorf("failed to find merge request by branch: %d matches found", len(mrs))
+	}
+}
+
+func (c *GitlabClient) createMergeRequestWithinRepository(projectPath, branchName, baseBranchName, mrTitle, mrText string) (string, error) {
+	opts := &gitlab.CreateMergeRequestOptions{
+		SourceBranch: &branchName,
+		TargetBranch: &baseBranchName,
+		Title:        &mrTitle,
+		Description:  &mrText,
+	}
+	mr, _, err := c.client.MergeRequests.CreateMergeRequest(projectPath, opts)
+	if err != nil {
+		return "", err
+	}
+	return mr.WebURL, nil
+}
+
+func (c *GitlabClient) getWebhookByTargetUrl(projectPath, webhookTargetUrl string) (*gitlab.ProjectHook, error) {
+	opts := &gitlab.ListProjectHooksOptions{PerPage: 100}
+	webhooks, _, err := c.client.Projects.ListProjectHooks(projectPath, opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, webhook := range webhooks {
+		if webhook.URL == webhookTargetUrl {
+			return webhook, nil
+		}
+	}
+	// Webhook with the given URL not found
+	return nil, nil
+}
+
+func (c *GitlabClient) createPaCWebhook(projectPath, webhookTargetUrl, webhookSecret string) (*gitlab.ProjectHook, error) {
+	opts := getPaCWebhookOpts(webhookTargetUrl, webhookSecret)
+	hook, _, err := c.client.Projects.AddProjectHook(projectPath, opts)
+	return hook, err
+}
+
+func (c *GitlabClient) updatePaCWebhook(projectPath string, webhookId int, webhookTargetUrl, webhookSecret string) (*gitlab.ProjectHook, error) {
+	opts := gitlab.EditProjectHookOptions(*getPaCWebhookOpts(webhookTargetUrl, webhookSecret))
+	hook, _, err := c.client.Projects.EditProjectHook(projectPath, webhookId, &opts)
+	return hook, err
+}
+
+func getPaCWebhookOpts(webhookTargetUrl, webhookSecret string) *gitlab.AddProjectHookOptions {
+	enableSSLVerification := false
+
+	mergeRequestsEvents := true
+	pushEvents := true
+	noteEvents := true
+
+	return &gitlab.AddProjectHookOptions{
+		URL:                   &webhookTargetUrl,
+		Token:                 &webhookSecret,
+		EnableSSLVerification: &enableSSLVerification,
+		MergeRequestsEvents:   &mergeRequestsEvents,
+		PushEvents:            &pushEvents,
+		NoteEvents:            &noteEvents,
+	}
+}

--- a/pkg/gitlab/gitlab_helper.go
+++ b/pkg/gitlab/gitlab_helper.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+// Allow mocking for tests
+var EnsurePaCMergeRequest func(g *GitlabClient, d *PaCMergeRequestData) (string, error) = ensurePaCMergeRequest
+var SetupPaCWebhook func(g *GitlabClient, projectPath, webhookUrl, webhookSecret string) error = setupPaCWebhook
+
+type File struct {
+	FullPath string
+	Content  []byte
+}
+
+type PaCMergeRequestData struct {
+	ProjectPath   string
+	CommitMessage string
+	Branch        string
+	BaseBranch    string
+	MrTitle       string
+	MrText        string
+	AuthorName    string
+	AuthorEmail   string
+	Files         []File
+}
+
+// ensurePaCMergeRequest creates a new merge request and returns its web URL
+func ensurePaCMergeRequest(glclient *GitlabClient, d *PaCMergeRequestData) (string, error) {
+	pacConfigurationUpToDate, err := glclient.filesUpToDate(d.ProjectPath, d.BaseBranch, d.Files)
+	if err != nil {
+		return "", err
+	}
+	if pacConfigurationUpToDate {
+		// Nothing to do, the configuration is alredy in the main branch of the repository
+		return "", nil
+	}
+
+	mrBranchExists, err := glclient.branchExist(d.ProjectPath, d.Branch)
+	if err != nil {
+		return "", err
+	}
+
+	if mrBranchExists {
+		mrBranchUpToDate, err := glclient.filesUpToDate(d.ProjectPath, d.Branch, d.Files)
+		if err != nil {
+			return "", err
+		}
+		if !mrBranchUpToDate {
+			err := glclient.commitFilesIntoBranch(d.ProjectPath, d.Branch, d.CommitMessage, d.AuthorName, d.AuthorEmail, d.Files)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		mr, err := glclient.findMergeRequestByBranches(d.ProjectPath, d.Branch, d.BaseBranch)
+		if err != nil {
+			return "", err
+		}
+		if mr != nil {
+			// Merge request already exists
+			return mr.WebURL, nil
+		}
+
+		diffExists, err := glclient.diffNotEmpty(d.ProjectPath, d.Branch, d.BaseBranch)
+		if err != nil {
+			return "", err
+		}
+		if !diffExists {
+			// This situation occurs if an MR was merged but the branch was not deleted and main is changed after the merge.
+			// Despite the fact that there is actual diff between branches, git treats it as no diff,
+			// because the branch is already "included" in main.
+			if err := glclient.deleteBranch(d.ProjectPath, d.Branch); err != nil {
+				return "", err
+			}
+			return ensurePaCMergeRequest(glclient, d)
+		}
+
+		return glclient.createMergeRequestWithinRepository(d.ProjectPath, d.Branch, d.BaseBranch, d.MrTitle, d.MrText)
+
+	} else {
+
+		// Need to create branch and MR with Pipelines as Code configuration
+		err = glclient.createBranch(d.ProjectPath, d.Branch, d.BaseBranch)
+		if err != nil {
+			return "", err
+		}
+
+		err = glclient.commitFilesIntoBranch(d.ProjectPath, d.Branch, d.CommitMessage, d.AuthorName, d.AuthorEmail, d.Files)
+		if err != nil {
+			return "", err
+		}
+
+		return glclient.createMergeRequestWithinRepository(d.ProjectPath, d.Branch, d.BaseBranch, d.MrTitle, d.MrText)
+	}
+}
+
+func setupPaCWebhook(glclient *GitlabClient, projectPath, webhookUrl, webhookSecret string) error {
+	existingWebhook, err := glclient.getWebhookByTargetUrl(projectPath, webhookUrl)
+	if err != nil {
+		return err
+	}
+
+	if existingWebhook == nil {
+		_, err = glclient.createPaCWebhook(projectPath, webhookUrl, webhookSecret)
+		return err
+	}
+
+	_, err = glclient.updatePaCWebhook(projectPath, existingWebhook.ID, webhookUrl, webhookSecret)
+	return err
+}

--- a/pkg/gitlab/gitlab_helper_debug_test.go
+++ b/pkg/gitlab/gitlab_helper_debug_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"strings"
+	"testing"
+)
+
+// THIS FILE IS NOT UNIT TESTS
+// Put your own data below and comment out function override in the test to debug interactions with GitLab
+var (
+	repoUrl     = "https://gitlab.com/user/devfile-sample-go-basic"
+	accessToken = "glpat-token"
+)
+
+var (
+	StubEnsurePaCMergeRequest = func(g *GitlabClient, d *PaCMergeRequestData) (string, error) { return "", nil }
+	StubSetupPaCWebhook       = func(g *GitlabClient, projectPath, webhookUrl, webhookSecret string) error { return nil }
+)
+
+func TestEnsurePaCMergeRequest(t *testing.T) {
+	EnsurePaCMergeRequest = StubEnsurePaCMergeRequest
+
+	glclient, err := NewGitlabClient(accessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipelineOnPush := []byte("pipelineOnPush:\n  bundle: 'test-bundle-1'\n  when: 'on-push'\n")
+	pipelineOnPR := []byte("pipelineOnMR:\n  bundle: 'test-bundle-2'\n  when: 'on-mr'\n")
+
+	componentName := "unittest-component-name"
+	gitSourceUrlParts := strings.Split(repoUrl, "/")
+	mrData := &PaCMergeRequestData{
+		ProjectPath:   gitSourceUrlParts[3] + "/" + gitSourceUrlParts[4],
+		CommitMessage: "Appstudio update " + componentName,
+		Branch:        "appstudio-" + componentName,
+		BaseBranch:    "main",
+		MrTitle:       "Appstudio update " + componentName,
+		MrText:        "Pipelines as Code configuration proposal",
+		AuthorName:    "redhat-appstudio",
+		AuthorEmail:   "appstudio@redhat.com",
+		Files: []File{
+			{FullPath: ".tekton/" + componentName + "-push.yaml", Content: pipelineOnPush},
+			{FullPath: ".tekton/" + componentName + "-merge-request.yaml", Content: pipelineOnPR},
+		},
+	}
+
+	url, err := EnsurePaCMergeRequest(glclient, mrData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "" && !strings.HasPrefix(url, "http") {
+		t.Fatal("Merge Request URL must not be empty")
+	}
+}
+
+func TestSetupPaCWebhook(t *testing.T) {
+	SetupPaCWebhook = StubSetupPaCWebhook
+
+	targetWebhookUrl := "https://pac.route.my-cluster.net"
+	webhookSecretString := "d01b38971dad59514298d763f288392c08221043"
+
+	glclient, err := NewGitlabClient(accessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitSourceUrlParts := strings.Split(repoUrl, "/")
+	projectPath := gitSourceUrlParts[3] + "/" + gitSourceUrlParts[4]
+
+	err = SetupPaCWebhook(glclient, projectPath, targetWebhookUrl, webhookSecretString)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Note: currently, Application Service fails to download devfile from GitLab. To workaround this, **URL to the devfile** must be explicitly set in the Component CR.

Example:
```yaml
apiVersion: appstudio.redhat.com/v1alpha1
kind: Component
metadata:
  annotations:
    pipelinesascode: "1"
  generation: 1
  name: devfile-sample-go-basic
  namespace: default
spec:
  application: test-application
  componentName: devfile-sample-go-basic
  containerImage: quay.io/username/devfile-sample-go-basic
  resources: {}
  source:
    git:
      url: https://gitlab.com/username/devfile-sample-go-basic
      devfileUrl:  https://gitlab.com/username/devfile-sample-go-basic/-/raw/main/devfile.yaml?inline=false
```