### PR TITLE
PLNSRVCE-431: Adds annotation to allow skipping the generation of PaC resources

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -104,7 +104,7 @@ func deleteApplication(resourceKey types.NamespacedName) {
 }
 
 // createComponent creates sample component resource and verifies it was properly created
-func createComponentForPaCBuild(componentLookupKey types.NamespacedName) {
+func createComponentForPaCBuild(componentLookupKey types.NamespacedName, skipPacResourceGeneration bool) {
 	component := &appstudiov1alpha1.Component{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "appstudio.redhat.com/v1alpha1",
@@ -130,6 +130,11 @@ func createComponentForPaCBuild(componentLookupKey types.NamespacedName) {
 			},
 		},
 	}
+
+	if skipPacResourceGeneration {
+		component.ObjectMeta.Annotations[skipPacResourceGenerationAnnotation] = "1"
+	}
+
 	Expect(k8sClient.Create(ctx, component)).Should(Succeed())
 
 	getComponent(componentLookupKey)


### PR DESCRIPTION
In order to migrate the components in the infra-deployments repository to use HAS Application/Component CRs, we need to avoid having the build-service spamming PRs for each time a new Component is created when a new cluster is bootrstraped.

This PR allows this behavior to be skipped in case an annotation is set in the related Component CR.