### PR TITLE
Make Secrets and ConfigMaps visible to the operator

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -123,11 +123,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&ComponentBuildReconciler{
-		Client:           k8sManager.GetClient(),
-		NonCachingClient: k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
-		Log:              ctrl.Log.WithName("controllers").WithName("ComponentOnboarding"),
-		EventRecorder:    k8sManager.GetEventRecorderFor("ComponentOnboarding"),
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("ComponentOnboarding"),
+		EventRecorder: k8sManager.GetEventRecorderFor("ComponentOnboarding"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Do not use `nonCachingClient` any more, instead use regular client with `ClientDisableCacheFor` option that's set to `Secret`s and `ConfigMap`s.
This change was made because regular non-caching client didn't work on KCP. As a consequence, build service operator didn't see build bundle ConfigMap and credentials Secrets, so Component image build was failing.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>