### PR TITLE
Restore Component Image controller

### DIFF
--- a/config/kcp/build-service-apibinding.yaml
+++ b/config/kcp/build-service-apibinding.yaml
@@ -39,3 +39,7 @@ spec:
     identityHash: applicationServiceIdentityHash
     resource: applications
     state: Accepted
+  - group: appstudio.redhat.com
+    identityHash: applicationServiceIdentityHash
+    resource: applicationsnapshots
+    state: Accepted

--- a/config/kcp/build-service-apiexport.yaml
+++ b/config/kcp/build-service-apiexport.yaml
@@ -27,3 +27,7 @@ spec:
       resource: "applications"
       # Replace by application-api identityHash
       identityHash: application-api
+    - group: "appstudio.redhat.com"
+      resource: "applicationsnapshots"
+      # Replace by application-api identityHash
+      identityHash: application-api

--- a/main.go
+++ b/main.go
@@ -167,18 +167,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO
-	// Temporary disabling this reconciler as TaskRun is not synced on KCP,
-	// so not visible on KCP, however, it's required for the controller.
-	// if err = (&controllers.ComponentImageReconciler{
-	// 	Client:        mgr.GetClient(),
-	// 	Scheme:        mgr.GetScheme(),
-	// 	Log:           ctrl.Log.WithName("controllers").WithName("ComponentImage"),
-	// 	EventRecorder: mgr.GetEventRecorderFor("ComponentImage"),
-	// }).SetupWithManager(mgr); err != nil {
-	// 	setupLog.Error(err, "unable to create controller", "controller", "ComponentImage")
-	// 	os.Exit(1)
-	// }
+	if err = (&controllers.ComponentImageReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("ComponentImage"),
+		EventRecorder: mgr.GetEventRecorderFor("ComponentImage"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ComponentImage")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Reworks Component Image controller to search for newly built image in pipeline results instead of build task results.

