### PR TITLE
Change expected location of PaC secret

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Component initial build controller", func() {
 		// All related to the component resources have the same key (but different type)
 		resourceKey           = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
 		pacRouteKey           = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
-		pacSecretKey          = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: pipelinesAsCodeNamespace}
+		pacSecretKey          = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
 		namespacePaCSecretKey = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
 		webhookSecretKey      = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
 	)
@@ -86,6 +86,7 @@ var _ = Describe("Component initial build controller", func() {
 		_ = BeforeEach(func() {
 			createNamespace(pipelinesAsCodeNamespace)
 			createRoute(pacRouteKey, "pac-host")
+			createNamespace(buildServiceNamespaceName)
 			pacSecretData := map[string]string{
 				"github-application-id": "12345",
 				"github-private-key":    githubAppPrivateKey,

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -363,7 +363,7 @@ components:
 }
 
 func TestValidatePaCConfiguration(t *testing.T) {
-	ghAppPrivateKeyStub := "-----BEGIN RSA PRIVATE KEY-----_key-content_-----END RSA PRIVATE KEY-----"
+	const ghAppPrivateKeyStub = "-----BEGIN RSA PRIVATE KEY-----_key-content_-----END RSA PRIVATE KEY-----"
 
 	tests := []struct {
 		name        string

--- a/controllers/component_image_controller.go
+++ b/controllers/component_image_controller.go
@@ -230,7 +230,7 @@ func (r *ComponentImageReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	application := &appstudiov1alpha1.Application{}
 	applicationKey := types.NamespacedName{Name: applicationName, Namespace: req.Namespace}
-	if err := r.Get(ctx, applicationKey, application); err != nil {
+	if err := r.Client.Get(ctx, applicationKey, application); err != nil {
 		log.Error(err, fmt.Sprintf("Failed to get application \"%s\"", applicationName))
 		return ctrl.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func getCacheFuncOptions() (*cache.Options, error) {
 	appStudioComponentPipelineRunSelector := labels.NewSelector().Add(*componentPipelineRunRequirement)
 
 	selectors := cache.SelectorsByObject{
-		&taskrunapi.PipelineRun{}: {
+		&taskrunapi.PipelineRun{}: cache.ObjectSelector{
 			Label: appStudioComponentPipelineRunSelector,
 		},
 	}


### PR DESCRIPTION
Expect PaC configuration secret (`pipelines-as-code-secret`) in the same namespace as component. If the secret is missing locally, fallback to global PaC configuration in `build-service` namespace (in case of KCP, in the operator deployment workspace).
