### PR TITLE
fix: avoid too long names of initial pipelinerun

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -873,7 +873,7 @@ func (r *ComponentBuildReconciler) SubmitNewBuild(ctx context.Context, component
 
 func generateInitialPipelineRunForComponent(component *appstudiov1alpha1.Component, pipelineRef *tektonapi.PipelineRef, additionalPipelineParams []tektonapi.Param) (*tektonapi.PipelineRun, error) {
 	timestamp := time.Now().Unix()
-	pipelineName := fmt.Sprintf("%s-initial-build-%d", component.Name, timestamp)
+	pipelineGenerateName := fmt.Sprintf("%s-", component.Name)
 	revision := "main"
 	if component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.Revision != "" {
 		revision = component.Spec.Source.GitSource.Revision
@@ -907,8 +907,8 @@ func generateInitialPipelineRunForComponent(component *appstudiov1alpha1.Compone
 			APIVersion: "tekton.dev/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pipelineName,
-			Namespace: component.Namespace,
+			GenerateName: pipelineGenerateName,
+			Namespace:    component.Namespace,
 			Labels: map[string]string{
 				ApplicationNameLabelName:                component.Spec.Application,
 				ComponentNameLabelName:                  component.Name,

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -66,8 +66,8 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 		t.Error("generateInitialPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
 
-	if pipelineRun.Name == "" {
-		t.Error("generateInitialPipelineRunForComponent(): pipeline name must not be empty")
+	if pipelineRun.GenerateName == "" {
+		t.Error("generateInitialPipelineRunForComponent(): pipeline generatename must not be empty")
 	}
 	if pipelineRun.Namespace != "my-namespace" {
 		t.Error("generateInitialPipelineRunForComponent(): pipeline namespace doesn't match")


### PR DESCRIPTION
Use GenerateName instead of Name for the initial pipelineRun