### PR TITLE
Allow skipping checks for initial build pipeline

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -889,6 +889,9 @@ func generateInitialPipelineRunForComponent(component *appstudiov1alpha1.Compone
 		{Name: "revision", Value: tektonapi.ArrayOrString{Type: "string", StringVal: revision}},
 		{Name: "output-image", Value: tektonapi.ArrayOrString{Type: "string", StringVal: image}},
 	}
+	if value, exists := component.Annotations["skip-initials-checks"]; exists && (value == "1" || strings.ToLower(value) == "true") {
+		params = append(params, tektonapi.Param{Name: "skip-checks", Value: tektonapi.ArrayOrString{Type: "string", StringVal: "true"}})
+	}
 
 	dockerFile, err := devfile.SearchForDockerfile([]byte(component.Status.Devfile))
 	if err != nil {

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -35,6 +35,9 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-component",
 			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"skip-initials-checks": "true",
+			},
 		},
 		Spec: appstudiov1alpha1.ComponentSpec{
 			Application:    "my-application",
@@ -100,7 +103,7 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 		t.Error("generateInitialPipelineRunForComponent(): wrong pipeline bundle in pipeline reference")
 	}
 
-	if len(pipelineRun.Spec.Params) != 4 {
+	if len(pipelineRun.Spec.Params) != 5 {
 		t.Error("generateInitialPipelineRunForComponent(): wrong number of pipeline params")
 	}
 	for _, param := range pipelineRun.Spec.Params {
@@ -118,6 +121,10 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 				t.Errorf("generateInitialPipelineRunForComponent(): wrong pipeline parameter %s value", param.Name)
 			}
 		case "rebuild":
+			if param.Value.StringVal != "true" {
+				t.Errorf("generateInitialPipelineRunForComponent(): wrong pipeline parameter %s value", param.Name)
+			}
+		case "skip-checks":
 			if param.Value.StringVal != "true" {
 				t.Errorf("generateInitialPipelineRunForComponent(): wrong pipeline parameter %s value", param.Name)
 			}


### PR DESCRIPTION
Adds `skip-checks` parameter to initial build pipeline if `skip-initial-checks` annotation is set to `true` or `1`.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>