### PR TITLE
Implement initial build provision metrics

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,13 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../prometheus
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,8 +9,13 @@ spec:
   template:
     spec:
       containers:
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -26,9 +31,4 @@ spec:
             memory: 128Mi
           requests:
             cpu: 5m
-            memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+            memory: 64Mi     

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - "--metrics-bind-address=127.0.0.1:8080"
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -41,12 +41,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"
 
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops"
 	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
@@ -76,7 +78,80 @@ const (
 
 	PartOfLabelName           = "app.kubernetes.io/part-of"
 	PartOfAppStudioLabelValue = "appstudio"
+
+	metricsNamespace = "redhat_appstudio"
+	metricsSubsystem = "buildservice"
 )
+
+var (
+	initialBuildPipelineCreationTimeMetric      prometheus.Histogram
+	pipelinesAsCodeComponentProvisionTimeMetric prometheus.Histogram
+)
+
+func initMetrics() error {
+	buckets := getProvisionTimeMetricsBuckets()
+
+	initialBuildPipelineCreationTimeMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Buckets:   buckets,
+		Name:      "initial_build_pipeline_creation_time",
+		Help:      "The time in seconds spent from the moment of Component creation till the initial build pipeline submition.",
+	})
+	pipelinesAsCodeComponentProvisionTimeMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Buckets:   buckets,
+		Name:      "PaC_configuration_time",
+		Help:      "The time in seconds spent from the moment of Component creation till Pipelines-as-Code configuration done in the Component source repository.",
+	})
+
+	if err := metrics.Registry.Register(initialBuildPipelineCreationTimeMetric); err != nil {
+		return fmt.Errorf("failed to register the initial_build_pipeline_creation_time metric: %w", err)
+	}
+	if err := metrics.Registry.Register(pipelinesAsCodeComponentProvisionTimeMetric); err != nil {
+		return fmt.Errorf("failed to register the PaC_configuration_time metric: %w", err)
+	}
+
+	return nil
+}
+
+func getProvisionTimeMetricsBuckets() []float64 {
+	// The map key is the bucket width, the value is the number of such buckets.
+	// 0 point is added separately.
+	bucketsRanges := map[int]int{
+		1:  15, // 15 * 1  sec = 15 sec, total 15 sec
+		5:  9,  //  9 * 5  sec = 45 sec, total 1 min
+		10: 6,  //  6 * 10 sec = 60 sec, total 2 min
+		15: 12, // 12 * 15 sec =  3 min, total 5 min
+	}
+	// 0,  1, 2, 3, ... 15, 20, 25, ... 60, 70, 80, ... 120, 135, 150, ... 300,  Inf
+
+	points := 0
+	for _, v := range bucketsRanges {
+		points += v
+	}
+	points++ // add point 0
+
+	buckets := make([]float64, points)
+
+	currentPoint := float64(0)
+	currentPointIndex := 0
+
+	// Add 0 point
+	buckets[currentPointIndex] = currentPoint
+
+	for width, n := range bucketsRanges {
+		for i := 0; i < n; i++ {
+			currentPointIndex++
+			currentPoint += float64(width)
+			buckets[currentPointIndex] = float64(currentPoint)
+		}
+	}
+	// The last bucket with Inf upper boundary will be added by metrics automatically.
+
+	return buckets
+}
 
 // ComponentBuildReconciler watches AppStudio Component object in order to submit builds
 type ComponentBuildReconciler struct {
@@ -88,6 +163,10 @@ type ComponentBuildReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := initMetrics(); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appstudiov1alpha1.Component{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
@@ -275,6 +354,11 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		log.Info(mrMessage)
 		r.EventRecorder.Event(&component, "Normal", "PipelinesAsCodeConfiguration", mrMessage)
+
+		if mrUrl != "" {
+			// PaC PR has been just created
+			pipelinesAsCodeComponentProvisionTimeMetric.Observe(time.Since(component.CreationTimestamp.Time).Seconds())
+		}
 
 		// Set initial build annotation to prevent recreation of the PaC integration PR
 		if err := r.Client.Get(ctx, req.NamespacedName, &component); err != nil {
@@ -867,6 +951,8 @@ func (r *ComponentBuildReconciler) SubmitNewBuild(ctx context.Context, component
 		log.Error(err, fmt.Sprintf("Unable to create the build PipelineRun %v", initialBuildPipelineRun))
 		return err
 	}
+
+	initialBuildPipelineCreationTimeMetric.Observe(time.Since(component.CreationTimestamp.Time).Seconds())
 
 	log.Info(fmt.Sprintf("Initial build pipeline %s created for component %s in %s namespace using %s pipeline from %s bundle",
 		initialBuildPipelineRun.Name, component.Name, component.Namespace, pipelineRef.Name, pipelineRef.Bundle))

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -117,40 +117,7 @@ func initMetrics() error {
 }
 
 func getProvisionTimeMetricsBuckets() []float64 {
-	// The map key is the bucket width, the value is the number of such buckets.
-	// 0 point is added separately.
-	bucketsRanges := map[int]int{
-		1:  15, // 15 * 1  sec = 15 sec, total 15 sec
-		5:  9,  //  9 * 5  sec = 45 sec, total 1 min
-		10: 6,  //  6 * 10 sec = 60 sec, total 2 min
-		15: 12, // 12 * 15 sec =  3 min, total 5 min
-	}
-	// 0,  1, 2, 3, ... 15, 20, 25, ... 60, 70, 80, ... 120, 135, 150, ... 300,  Inf
-
-	points := 0
-	for _, v := range bucketsRanges {
-		points += v
-	}
-	points++ // add point 0
-
-	buckets := make([]float64, points)
-
-	currentPoint := float64(0)
-	currentPointIndex := 0
-
-	// Add 0 point
-	buckets[currentPointIndex] = currentPoint
-
-	for width, n := range bucketsRanges {
-		for i := 0; i < n; i++ {
-			currentPointIndex++
-			currentPoint += float64(width)
-			buckets[currentPointIndex] = float64(currentPoint)
-		}
-	}
-	// The last bucket with Inf upper boundary will be added by metrics automatically.
-
-	return buckets
+	return []float64{5, 10, 15, 20, 30, 60, 120, 300}
 }
 
 // ComponentBuildReconciler watches AppStudio Component object in order to submit builds

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -30,6 +30,16 @@ import (
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
+func TestGetProvisionTimeMetricsBuckets(t *testing.T) {
+	buckets := getProvisionTimeMetricsBuckets()
+	for i := 1; i < len(buckets); i++ {
+		if buckets[i] <= buckets[i-1] {
+			t.Errorf("Buckets must be in increasing order, but got: %v", buckets)
+		}
+	}
+
+}
+
 func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 	component := &appstudiov1alpha1.Component{
 		ObjectMeta: metav1.ObjectMeta{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift/api v0.0.0-20221013123534-96eec44e1979
+	github.com/prometheus/client_golang v1.12.1
 	github.com/xanzy/go-gitlab v0.68.2
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
@@ -112,7 +113,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,6 @@ github.com/openshift-pipelines/pipelines-as-code v0.11.0/go.mod h1:zfYE14Bp20LQB
 github.com/openshift/api v0.0.0-20200930075302-db52bc4ef99f/go.mod h1:Si/I9UGeRR3qzg01YWPmtlr0GeGk2fnuggXJRmjAZ6U=
 github.com/openshift/api v0.0.0-20221013123534-96eec44e1979 h1:NkfbwN34Q/UtfKUFEO9pxmdY06A/jBk80YBua+mxwUc=
 github.com/openshift/api v0.0.0-20221013123534-96eec44e1979/go.mod h1:LEnw1IVscIxyDnltE3Wi7bQb/QzIM8BfPNKoGA1Qlxw=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=

--- a/main.go
+++ b/main.go
@@ -72,13 +72,11 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var apiExportName string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&apiExportName, "api-export-name", "build-service-apiexport", "The name of the APIExport.")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
This PR adds two prometheus metrics:
 - Time spent from the component creation till initial build pipeline created.
 - Time spent from the component creation till the component repository is provisioned for Pipelines-as-Code.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>
