### PR TITLE
Allow PaC onboarding after component creation

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
@@ -53,6 +54,7 @@ var (
 	testEnv   *envtest.Environment
 	ctx       context.Context
 	cancel    context.CancelFunc
+	log       logr.Logger
 )
 
 func TestAPIs(t *testing.T) {
@@ -67,6 +69,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	log = ctrl.Log.WithName("testdebug")
 
 	By("bootstrapping test environment")
 	applicationServiceDepVersion := "v0.0.0-20221129172232-763cbbe1992e"


### PR DESCRIPTION
This PR allows to do Pipelines as Code provision for Components after they have been created.
In order to do the PaC provision, add `appstudio.openshift.io/pac-provision=request`annotation to the component. When the provision finished successfully, the annotation will be updated by the operator to `appstudio.openshift.io/pac-provision=done`.

Also, initial build annotation name is changed from `com.redhat.appstudio/component-initial-build-processed` to `appstudio.openshift.io/component-initial-build` which is a **breaking change**.
To submit another initial build just delete the annotation (works only if `appstudio.openshift.io/pac-provision` annotation is not set).

