### PR TITLE
Avoid linking empty secret to serviceaccount

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -1102,6 +1102,10 @@ func getGitProviderUrl(gitURL string) (string, error) {
 }
 
 func updateServiceAccountIfSecretNotLinked(gitSecretName string, serviceAccount *corev1.ServiceAccount) bool {
+	if gitSecretName == "" {
+		// The secret is empty, no updates needed
+		return false
+	}
 	for _, credentialSecret := range serviceAccount.Secrets {
 		if credentialSecret.Name == gitSecretName {
 			// The secret is present in the service account, no updates needed

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -421,6 +421,20 @@ func TestUpdateServiceAccountIfSecretNotLinked(t *testing.T) {
 			},
 			want: true, // since it wasn't present, this implies the SA was updated.
 		},
+		{
+			name: "secretname is empty string",
+			args: args{
+				gitSecretName: "",
+				serviceAccount: &corev1.ServiceAccount{
+					Secrets: []corev1.ObjectReference{
+						{
+							Name: "present",
+						},
+					},
+				},
+			},
+			want: false, // since it wasn't present, this implies the SA was updated.
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Avoid creation of {} in pipeline SA:
```
$ oc get sa -o yaml pipeline
apiVersion: v1
kind: ServiceAccount
metadata:
  name: pipeline
  namespace: default
secrets:
- name: pipeline-dockercfg-sqkhb
- {}
```