### PR TITLE
Implement permananent errors detection prototype

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -247,6 +247,8 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		component.Annotations[PaCProvisionAnnotationName] = pacAnnotationValue
 		if pacPersistentErrorMessage != "" {
 			component.Annotations[PaCProvisionErrorDetailsAnnotationName] = pacPersistentErrorMessage
+		} else {
+			delete(component.Annotations, PaCProvisionErrorDetailsAnnotationName)
 		}
 
 		// Add finalizer to clean up Pipelines as Code configuration on component deletion

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redhat-appstudio/application-service/gitops"
 	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
 	buildappstudiov1alpha1 "github.com/redhat-appstudio/build-service/api/v1alpha1"
+	"github.com/redhat-appstudio/build-service/pkg/boerrors"
 	"github.com/redhat-appstudio/build-service/pkg/github"
 	"github.com/redhat-appstudio/build-service/pkg/gitlab"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -297,10 +298,6 @@ var _ = Describe("Component initial build controller", func() {
 		})
 
 		It("should reuse the same webhook secret for multicomponent repository", func() {
-			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
-				return "", nil
-			}
-
 			var webhookSecretStrings []string
 			github.SetupPaCWebhook = func(g *github.GithubClient, webhookUrl, webhookSecret, owner, repository string) error {
 				webhookSecretStrings = append(webhookSecretStrings, webhookSecret)
@@ -340,10 +337,6 @@ var _ = Describe("Component initial build controller", func() {
 		})
 
 		It("should use different webhook secrets for different components of the same application", func() {
-			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
-				return "", nil
-			}
-
 			var webhookSecretStrings []string
 			github.SetupPaCWebhook = func(g *github.GithubClient, webhookUrl, webhookSecret, owner, repository string) error {
 				webhookSecretStrings = append(webhookSecretStrings, webhookSecret)
@@ -401,6 +394,54 @@ var _ = Describe("Component initial build controller", func() {
 			// The reason for this is that the test operator could be in the middle of reconcile loop
 			// and it's needed to wait until execution reaches the end of the reconcile loop.
 			time.Sleep(time.Second)
+		})
+
+		It("should successfully do PaC provision after error (when PaC GitHub Application was not installed)", func() {
+			appNotInstalledErr := boerrors.NewBuildOpError(boerrors.EGitHubAppNotInstalled, nil)
+			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) {
+				return nil, appNotInstalledErr
+			}
+			github.NewGithubClient = func(accessToken string) *github.GithubClient {
+				defer GinkgoRecover()
+				Fail("GitHub client should be created using PaC GitHub Application")
+				return nil
+			}
+			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
+				defer GinkgoRecover()
+				Fail("PR creation should not be invoked")
+				return "", nil
+			}
+
+			setComponentDevfileModel(resourceKey)
+			waitComponentAnnotationValue(resourceKey, PaCProvisionAnnotationName, PaCProvisionErrorAnnotationValue)
+			waitComponentAnnotationValue(resourceKey, PaCProvisionErrorDetailsAnnotationName, appNotInstalledErr.ShortError())
+
+			// Ensure no more retries after permanent error
+			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) {
+				defer GinkgoRecover()
+				Fail("Should not retry PaC provision on permanent error")
+				return nil, nil
+			}
+			ensureComponentAnnotationValue(resourceKey, PaCProvisionAnnotationName, PaCProvisionErrorAnnotationValue)
+
+			// Suppose PaC GH App is installed
+			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) {
+				return nil, nil
+			}
+			isCreatePaCPullRequestInvoked := false
+			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
+				isCreatePaCPullRequestInvoked = true
+				return "url", nil
+			}
+			// Update PaC annotation to retry
+			component := getComponent(resourceKey)
+			component.Annotations[PaCProvisionAnnotationName] = PaCProvisionRequestedAnnotationValue
+			Expect(k8sClient.Update(ctx, component)).Should(Succeed())
+
+			Eventually(func() bool {
+				return isCreatePaCPullRequestInvoked
+			}, timeout, interval).Should(BeTrue())
+			waitComponentAnnotationValue(resourceKey, PaCProvisionAnnotationName, PaCProvisionDoneAnnotationValue)
 		})
 
 		It("should not submit PaC definitions PR if PaC secret is missing", func() {

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -37,7 +37,6 @@ func TestGetProvisionTimeMetricsBuckets(t *testing.T) {
 			t.Errorf("Buckets must be in increasing order, but got: %v", buckets)
 		}
 	}
-
 }
 
 func TestGenerateInitialPipelineRunForComponent(t *testing.T) {

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package boerrors
+
+import (
+	"fmt"
+)
+
+// BuildOpError extends standard error to:
+//  1. Keep persistent / transient property of the error.
+//     All errors, except ETransientErrorId considered persistent.
+//  2. Have error ID to show the root cause of the error and optionally short message.
+type BuildOpError struct {
+	// id is used to determine if error is persistent and to know the root cause of the error
+	id BOErrorId
+	// typically used to log the error message along with nested errors
+	err error
+}
+
+func NewBuildOpError(id BOErrorId, err error) *BuildOpError {
+	return &BuildOpError{
+		id:  id,
+		err: err,
+	}
+}
+
+func (r BuildOpError) Error() string {
+	return r.err.Error()
+}
+
+// ShortError returns short message with error ID in case of persistent error or
+// standard error message for transient errors.
+func (r BuildOpError) ShortError() string {
+	if r.id == ETransientError {
+		return r.Error()
+	}
+	return fmt.Sprintf("error %d: %s", r.id, boErrorMessages[r.id])
+}
+
+func (r BuildOpError) IsPersistent() bool {
+	return r.id != ETransientError
+}
+
+type BOErrorId int
+
+const (
+	ETransientError BOErrorId = 0
+	EUnknownError   BOErrorId = 1
+
+	// 'pipelines-as-code-secret' secret doesn't exists in 'build-service' namespace nor Component's one.
+	EPaCSecretNotFound BOErrorId = 90
+	// Validation of 'pipelines-as-code-secret' secret failed
+	EPaCSecretInvalid BOErrorId = 91
+
+	// Happens when Component source repository is hosted on unsupported / unknown git provider.
+	// For example: https://my-gitlab.com
+	// If self-hosted instance of the supported git providers is used, then "git-provider" annotation must be set:
+	// git-provider: gitlab
+	EUnknownGitProvider BOErrorId = 100
+
+	// Happens when configured in cluster Pipelines as Code application is not installed in Component source repository.
+	// User must install the application to fix this error.
+	EGitHubAppNotInstalled BOErrorId = 120
+	// Bad formatted private key
+	EGitHubAppInvalidPrivateKey BOErrorId = 121
+	// Private key doesn't match the GitHun Application
+	EGitHubAppWrongPrivateKey BOErrorId = 122
+	// GitHub Application with specified ID does not exists.
+	// Correct configuration in the AppStudio installation ('pipelines-as-code-secret' secret in 'build-service' namespace).
+	EGitHubAppDoesNotExist BOErrorId = 123
+)
+
+var boErrorMessages = map[BOErrorId]string{
+	ETransientError: "",
+	EUnknownError:   "unknown error",
+
+	EPaCSecretNotFound: "Pipelines as Code secret does not exist",
+	EPaCSecretInvalid:  "Invalid Pipelines as Code secret",
+
+	EUnknownGitProvider: "unknown git provider of the source repository",
+
+	EGitHubAppNotInstalled:      "GitHub Application is not installed in user repository",
+	EGitHubAppInvalidPrivateKey: "invalid GitHub Application private key",
+	EGitHubAppWrongPrivateKey:   "GitHub Application private key does not match Application ID",
+	EGitHubAppDoesNotExist:      "GitHub Application with given ID does not exist",
+}

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -48,7 +48,7 @@ func (r BuildOpError) ShortError() string {
 	if r.id == ETransientError {
 		return r.Error()
 	}
-	return fmt.Sprintf("error %d: %s", r.id, boErrorMessages[r.id])
+	return fmt.Sprintf("%d: %s", r.id, boErrorMessages[r.id])
 }
 
 func (r BuildOpError) IsPersistent() bool {

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 )
 
+var _ error = (*BuildOpError)(nil)
+
 // BuildOpError extends standard error to:
 //  1. Keep persistent / transient property of the error.
 //     All errors, except ETransientErrorId considered persistent.
@@ -39,6 +41,9 @@ func NewBuildOpError(id BOErrorId, err error) *BuildOpError {
 }
 
 func (r BuildOpError) Error() string {
+	if r.err == nil {
+		return ""
+	}
 	return r.err.Error()
 }
 
@@ -62,26 +67,26 @@ const (
 	EUnknownError   BOErrorId = 1
 
 	// 'pipelines-as-code-secret' secret doesn't exists in 'build-service' namespace nor Component's one.
-	EPaCSecretNotFound BOErrorId = 90
+	EPaCSecretNotFound BOErrorId = 50
 	// Validation of 'pipelines-as-code-secret' secret failed
-	EPaCSecretInvalid BOErrorId = 91
+	EPaCSecretInvalid BOErrorId = 51
 
 	// Happens when Component source repository is hosted on unsupported / unknown git provider.
 	// For example: https://my-gitlab.com
 	// If self-hosted instance of the supported git providers is used, then "git-provider" annotation must be set:
 	// git-provider: gitlab
-	EUnknownGitProvider BOErrorId = 100
+	EUnknownGitProvider BOErrorId = 60
 
 	// Happens when configured in cluster Pipelines as Code application is not installed in Component source repository.
 	// User must install the application to fix this error.
-	EGitHubAppNotInstalled BOErrorId = 120
+	EGitHubAppNotInstalled BOErrorId = 70
 	// Bad formatted private key
-	EGitHubAppInvalidPrivateKey BOErrorId = 121
-	// Private key doesn't match the GitHun Application
-	EGitHubAppWrongPrivateKey BOErrorId = 122
+	EGitHubAppMalformedPrivateKey BOErrorId = 71
+	// Private key doesn't match the GitHub Application
+	EGitHubAppPrivateKeyNotMatched BOErrorId = 72
 	// GitHub Application with specified ID does not exists.
 	// Correct configuration in the AppStudio installation ('pipelines-as-code-secret' secret in 'build-service' namespace).
-	EGitHubAppDoesNotExist BOErrorId = 123
+	EGitHubAppDoesNotExist BOErrorId = 73
 )
 
 var boErrorMessages = map[BOErrorId]string{
@@ -93,8 +98,8 @@ var boErrorMessages = map[BOErrorId]string{
 
 	EUnknownGitProvider: "unknown git provider of the source repository",
 
-	EGitHubAppNotInstalled:      "GitHub Application is not installed in user repository",
-	EGitHubAppInvalidPrivateKey: "invalid GitHub Application private key",
-	EGitHubAppWrongPrivateKey:   "GitHub Application private key does not match Application ID",
-	EGitHubAppDoesNotExist:      "GitHub Application with given ID does not exist",
+	EGitHubAppNotInstalled:         "GitHub Application is not installed in user repository",
+	EGitHubAppMalformedPrivateKey:  "invalid GitHub Application private key",
+	EGitHubAppPrivateKeyNotMatched: "GitHub Application private key does not match Application ID",
+	EGitHubAppDoesNotExist:         "GitHub Application with given ID does not exist",
 }

--- a/pkg/boerrors/perror_test.go
+++ b/pkg/boerrors/perror_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package boerrors
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPersistentErrorDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		errId       BOErrorId
+		nestedError error
+		isPersitent bool
+	}{
+		{
+			name:        "should treat transient error as not persistent",
+			errId:       ETransientError,
+			nestedError: fmt.Errorf("network error"),
+			isPersitent: false,
+		},
+		{
+			name:        "should treat PaC GH App not installed error as persistent",
+			errId:       EGitHubAppNotInstalled,
+			nestedError: fmt.Errorf("App with given id not found"),
+			isPersitent: true,
+		},
+		{
+			name:        "should treat any non transient error as persistent",
+			errId:       EUnknownError,
+			nestedError: fmt.Errorf("An error"),
+			isPersitent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boErr := NewBuildOpError(tt.errId, tt.nestedError)
+			if boErr.IsPersistent() != tt.isPersitent {
+				t.Errorf("Wrong error persistance")
+			}
+		})
+	}
+}
+
+func TestNestedErrorMessage(t *testing.T) {
+	tests := []struct {
+		name                       string
+		nestedError                error
+		expectedNestedErrorMessage string
+	}{
+		{
+			name:                       "should return nested error message",
+			nestedError:                fmt.Errorf("invalid credentials"),
+			expectedNestedErrorMessage: "invalid credentials",
+		},
+		{
+			name:                       "should return empty string if nested error is nil",
+			nestedError:                nil,
+			expectedNestedErrorMessage: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boErr := NewBuildOpError(EUnknownError, tt.nestedError)
+			if boErr.Error() != tt.expectedNestedErrorMessage {
+				t.Errorf("Expected \"%s\" error message, but got \"%s\"", tt.expectedNestedErrorMessage, boErr.Error())
+			}
+		})
+	}
+}
+
+func TestShortErrorMessage(t *testing.T) {
+	tests := []struct {
+		name                 string
+		errId                BOErrorId
+		expectedShortMessage string
+	}{
+		{
+			name:                 "should return short error message",
+			errId:                EGitHubAppNotInstalled,
+			expectedShortMessage: "70: GitHub Application is not installed in user repository",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boErr := NewBuildOpError(tt.errId, nil)
+			if boErr.ShortError() != tt.expectedShortMessage {
+				t.Errorf("Expected \"%s\" error message, but got \"%s\"", tt.expectedShortMessage, boErr.Error())
+			}
+		})
+	}
+}

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -58,7 +58,7 @@ func newGithubClientByApp(appId int64, privateKeyPem []byte, owner string) (*Git
 	itr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appId, privateKeyPem) // 172616 (appstudio) 184730(Michkov)
 	if err != nil {
 		// Inability to create transport based on a private key indicates that the key is bad formatted
-		return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppInvalidPrivateKey, err)
+		return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppMalformedPrivateKey, err)
 	}
 	client := github.NewClient(&http.Client{Transport: itr})
 
@@ -72,7 +72,7 @@ func newGithubClientByApp(appId int64, privateKeyPem []byte, owner string) (*Git
 			if resp != nil && resp.Response != nil && resp.Response.StatusCode != 0 {
 				switch resp.StatusCode {
 				case 401:
-					return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppWrongPrivateKey, err)
+					return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppPrivateKeyNotMatched, err)
 				case 404:
 					return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppDoesNotExist, err)
 				}


### PR DESCRIPTION
A proposal on how to handle permanent / transient errors in build service operator.

The goal of this PR is to create a prototype which allows to detect and properly handle permanent errors that occur in Build Service operator. An example of such error is invalid configuration provided by user, so the operator cannot continue without change from user side.

To solve the above, This PR adds a custom error type that holds root reason of the persistent error (error id). Also, there is a short error message attached to each error id. If an error is transient (temporary error, like network lag), then special error id is used for all of such errors, so later operator can just log that and retry.

As an example, situation when user's Component source code repository doesn't have Pipelines as Code GitHub application installed is taken. In such case, the operator cannot continue until user installs the application into the Component repository on GitHub.
The flow is the following: the error (persistent) is identified, then a new error id is created for it. In all places where it might happen, an error object that holds such id is created. Later, when Pipelines as Code provision result is analyzed, check for an persistent error is done, and the operator updates the component to let the user know about the error (in this particular case we update annotations, but any logic could be applied).