### PR TITLE
STONEBLD-870: git-tekton-resources-renovater

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,6 +59,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -254,16 +254,6 @@ func (r *GitTektonResourcesRenovater) CreateRenovaterJob(ctx context.Context, in
 		},
 	}
 
-	if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	if err := r.Client.Delete(ctx, secret); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
 	if err := r.Client.Create(ctx, secret); err != nil {
 		return err
 	}

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -91,13 +91,13 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 		if !errors.IsNotFound(err) {
 			r.EventRecorder.Event(&pacSecret, "Warning", "ErrorReadingPaCSecret", err.Error())
 			r.Log.Error(err, "failed to get Pipelines as Code secret in %s namespace: %w", globalPaCSecretKey.Namespace, err)
-			os.Exit(1)
+			return ctrl.Result{}, nil
 		}
 	}
 	isApp := gitops.IsPaCApplicationConfigured("github", pacSecret.Data)
 	if !isApp {
 		r.Log.Info("GitHub App is not set")
-		return ctrl.Result{RequeueAfter: NextReconcile}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// Load GitHub App and get GitHub Installations
@@ -105,7 +105,7 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 	githubAppId, err := strconv.ParseInt(githubAppIdStr, 10, 64)
 	if err != nil {
 		r.Log.Error(err, "failed to convert %s to int: %w", githubAppIdStr, err)
-		os.Exit(1)
+		return ctrl.Result{}, nil
 	}
 	privateKey := pacSecret.Data[gitops.PipelinesAsCode_githubPrivateKey]
 	installations, slug, err := github.GetInstallations(githubAppId, privateKey)

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/redhat-appstudio/application-service/gitops"
+	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
+	buildappstudiov1alpha1 "github.com/redhat-appstudio/build-service/api/v1alpha1"
+	"github.com/redhat-appstudio/build-service/pkg/github"
+	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	RenovateConfigName = "renovate-config"
+	RenovateImageUrl   = "quay.io/redhat-appstudio/renovate:34.154-slim"
+)
+
+// GitTektonResourcesRenovater watches AppStudio BuildPipelineSelector object in order to update
+// existing .tekton directories.
+type GitTektonResourcesRenovater struct {
+	Client        client.Client
+	Scheme        *runtime.Scheme
+	Log           logr.Logger
+	EventRecorder record.EventRecorder
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GitTektonResourcesRenovater) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&buildappstudiov1alpha1.BuildPipelineSelector{}).Complete(r)
+}
+
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;delete;deletecollection
+
+func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	// Only process main buildPipelineSelector
+	if req.Namespace != buildServiceNamespaceName && req.Name != buildPipelineSelectorResourceName {
+		return ctrl.Result{}, nil
+	}
+
+	// Check if GitHub Application is used, if not then skip
+	pacSecret := corev1.Secret{}
+	globalPaCSecretKey := types.NamespacedName{Namespace: buildServiceNamespaceName, Name: gitopsprepare.PipelinesAsCodeSecretName}
+	if err := r.Client.Get(ctx, globalPaCSecretKey, &pacSecret); err != nil {
+		if !errors.IsNotFound(err) {
+			r.EventRecorder.Event(&pacSecret, "Warning", "ErrorReadingPaCSecret", err.Error())
+			return ctrl.Result{}, fmt.Errorf("failed to get Pipelines as Code secret in %s namespace: %w", globalPaCSecretKey.Namespace, err)
+		}
+	}
+	isApp := gitops.IsPaCApplicationConfigured("github", pacSecret.Data)
+	if !isApp {
+		r.Log.Info("GitHub App is not set")
+		return ctrl.Result{}, nil
+	}
+
+	// Load GitHub App and get GitHub Installations
+	githubAppIdStr := string(pacSecret.Data[gitops.PipelinesAsCode_githubAppIdKey])
+	githubAppId, err := strconv.ParseInt(githubAppIdStr, 10, 64)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to convert %s to int: %w", githubAppIdStr, err)
+	}
+	privateKey := pacSecret.Data[gitops.PipelinesAsCode_githubPrivateKey]
+	installations, slug, err := github.GetInstallations(githubAppId, privateKey)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update config.js file for Jobs
+	configmap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: RenovateConfigName, Namespace: buildServiceNamespaceName},
+		Data: map[string]string{
+			"config.js": generateConfigJS(slug),
+		},
+	}
+	if err := r.Client.Delete(ctx, &configmap); err != nil {
+		if !errors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	}
+	if err := r.Client.Create(ctx, &configmap); err != nil {
+		r.Log.Error(err, "failed to create configmap")
+		return ctrl.Result{}, err
+	}
+	for _, installation := range installations {
+		err = r.CreateRenovaterJob(ctx, installation)
+		if err != nil {
+			r.Log.Error(err, "failed to create a job")
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	return ctrl.Result{RequeueAfter: 10 * time.Hour}, nil
+}
+
+func generateConfigJS(slug string) string {
+	template := `
+	module.exports = {
+		username: "%s[bot]",
+		gitAuthor:"AppStudio <123456+%s[bot]@users.noreply.github.com>",
+		onboarding: false,
+		requireConfig: "ignored",
+		autodiscover: true,
+		enabledManagers: ["tekton"],
+		tekton: {
+			fileMatch: ["\\.yaml$", "\\.yml$"],
+			includePaths: [".tekton/**"],
+			packageRules: [
+			  {
+				matchPackagePatterns: ["*"],
+				groupName: "tekton references"
+			  }
+			]
+		},
+		includeForks: true,
+		dependencyDashboard: false
+	}
+	`
+	return fmt.Sprintf(template, slug, slug)
+}
+
+func (r *GitTektonResourcesRenovater) CreateRenovaterJob(ctx context.Context, installation github.ApplicationInstallation) error {
+	name := fmt.Sprintf("renovate-job-%d", installation.InstallationID)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: buildServiceNamespaceName,
+		},
+		StringData: map[string]string{
+			"token": installation.Token,
+		},
+	}
+	trueBool := true
+	falseBool := false
+	backoffLimit := int32(1)
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: buildServiceNamespaceName,
+		},
+		Spec: batch.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: RenovateConfigName,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: RenovateConfigName},
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "renovate",
+							Image: RenovateImageUrl,
+							Env: []corev1.EnvVar{
+								{
+									Name: "RENOVATE_TOKEN",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: name,
+											},
+											Key: "token",
+										},
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      RenovateConfigName,
+									MountPath: "/usr/src/app/config.js",
+									SubPath:   "config.js",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+								RunAsNonRoot:             &trueBool,
+								AllowPrivilegeEscalation: &falseBool,
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+	if err := r.Client.Delete(ctx, secret); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	if err := r.Client.Create(ctx, secret); err != nil {
+		return err
+	}
+	if err := r.Client.Create(ctx, job); err != nil {
+		return err
+	}
+	r.Log.Info(fmt.Sprintf("Job %s triggered", job.Name))
+	return nil
+}

--- a/controllers/git_tekton_resources_renovater_test.go
+++ b/controllers/git_tekton_resources_renovater_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
+	"github.com/redhat-appstudio/build-service/pkg/github"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Git tekton resources renovater", func() {
+
+	var (
+		// All related to the component resources have the same key (but different type)
+		pacSecretKey    = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
+		defaultSelector = types.NamespacedName{Name: buildPipelineSelectorResourceName, Namespace: buildServiceNamespaceName}
+	)
+
+	Context("Test Renovate jobs creation", Label("renovater"), func() {
+
+		_ = BeforeEach(func() {
+			createNamespace(buildServiceNamespaceName)
+			pacSecretData := map[string]string{
+				"github-application-id": "12345",
+				"github-private-key":    githubAppPrivateKey,
+			}
+			createSecret(pacSecretKey, pacSecretData)
+		})
+
+		_ = AfterEach(func() {
+			deleteBuildPipelineRunSelector(defaultSelector)
+			deleteJobs(buildServiceNamespaceName)
+		})
+
+		It("It should not trigger job", func() {
+			github.GetInstallations = func(appId int64, privateKeyPem []byte) ([]github.ApplicationInstallation, string, error) {
+				return generateInstallations(0), "slug", nil
+			}
+			createBuildPipelineRunSelector(defaultSelector)
+			time.Sleep(time.Second)
+			Expect(listJobs(buildServiceNamespaceName)).Should(BeEmpty())
+		})
+		It("It should trigger job", func() {
+			github.GetInstallations = func(appId int64, privateKeyPem []byte) ([]github.ApplicationInstallation, string, error) {
+				return generateInstallations(1), "slug", nil
+			}
+			createBuildPipelineRunSelector(defaultSelector)
+			time.Sleep(time.Second)
+			Expect(listJobs(buildServiceNamespaceName)).Should(HaveLen(1))
+		})
+		It("It should trigger 3 jobs", func() {
+			github.GetInstallations = func(appId int64, privateKeyPem []byte) ([]github.ApplicationInstallation, string, error) {
+				return generateInstallations(InstallationsPerJob*2 + 1), "slug", nil
+			}
+			createBuildPipelineRunSelector(defaultSelector)
+			time.Sleep(time.Second)
+			Expect(listJobs(buildServiceNamespaceName)).Should(HaveLen(3))
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -138,6 +138,14 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&GitTektonResourcesRenovater{
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("GitTektonResourcesRenovater"),
+		EventRecorder: k8sManager.GetEventRecorderFor("GitTektonResourcesRenovater"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)

--- a/main.go
+++ b/main.go
@@ -145,6 +145,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.GitTektonResourcesRenovater{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Log:           ctrl.Log.WithName("controllers").WithName("GitTektonResourcesRenovater"),
+		EventRecorder: mgr.GetEventRecorderFor("GitTektonResourcesRenovater"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GitTektonResourcesRenovater")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -34,6 +34,7 @@ import (
 // Allow mocking for tests
 var NewGithubClientByApp func(appId int64, privateKeyPem []byte, owner string) (*GithubClient, error) = newGithubClientByApp
 var NewGithubClient func(accessToken string) *GithubClient = newGithubClient
+var GetInstallations func(appId int64, privateKeyPem []byte) ([]ApplicationInstallation, string, error) = getInstallations
 
 type GithubClient struct {
 	ctx    context.Context
@@ -112,7 +113,7 @@ func newGithubClientByApp(appId int64, privateKeyPem []byte, owner string) (*Git
 	return NewGithubClient(token.GetToken()), nil
 }
 
-func GetInstallations(appId int64, privateKeyPem []byte) ([]ApplicationInstallation, string, error) {
+func getInstallations(appId int64, privateKeyPem []byte) ([]ApplicationInstallation, string, error) {
 	itr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appId, privateKeyPem)
 	if err != nil {
 		// Inability to create transport based on a private key indicates that the key is bad formatted

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -113,7 +113,7 @@ func newGithubClientByApp(appId int64, privateKeyPem []byte, owner string) (*Git
 }
 
 func GetInstallations(appId int64, privateKeyPem []byte) ([]ApplicationInstallation, string, error) {
-	itr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appId, privateKeyPem) // 172616 (appstudio) 184730(Michkov)
+	itr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appId, privateKeyPem)
 	if err != nil {
 		// Inability to create transport based on a private key indicates that the key is bad formatted
 		return nil, "", boerrors.NewBuildOpError(boerrors.EGitHubAppMalformedPrivateKey, err)
@@ -124,6 +124,9 @@ func GetInstallations(appId int64, privateKeyPem []byte) ([]ApplicationInstallat
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	githubApp, _, err := client.Apps.Get(context.Background(), "")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load GitHub app metadata, %w", err)
+	}
 	slug := (githubApp.GetSlug())
 	for {
 		installations, resp, err := client.Apps.ListInstallations(context.Background(), &opt.ListOptions)


### PR DESCRIPTION
Adding git-tekton-resources-renovater - new controller which is creating
Jobs with renovate application per each GitHub App Installations.

- Triggered by BuildPipelineSelector in build-service namespace change
- Gets token for each GitHub App Installation
- Generates Job per each GitHub App Installation with the token, 10
  seconds delay between job trigger
- Renovate bot running in Job:
  - updates only .tekton folders and only tekton bundle references
  - ignores any configuration in repository
