### PR TITLE
STONEBLD-914: reduce scope to repositories in the cluster

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -180,8 +180,11 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 	// Generate renovate jobs. Limit processed installations per job.
 	var installationPerJobInt int
 	installationPerJobStr := os.Getenv(InstallationsPerJobEnvName)
-	if regexp.MustCompile(`\d`).MatchString(installationPerJobStr) {
+	if regexp.MustCompile(`^\d{1,2}$`).MatchString(installationPerJobStr) {
 		installationPerJobInt, _ = strconv.Atoi(installationPerJobStr)
+		if installationPerJobInt == 0 {
+			installationPerJobInt = InstallationsPerJob
+		}
 	} else {
 		installationPerJobInt = InstallationsPerJob
 	}

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -131,7 +131,7 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 	privateKey := pacSecret.Data[gitops.PipelinesAsCode_githubPrivateKey]
-	githubInstallations, slug, err := github.GetInstallations(githubAppId, privateKey)
+	githubAppInstallations, slug, err := github.GetInstallations(githubAppId, privateKey)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -152,9 +152,9 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Match installed repositories with Components and get custom branch if defined
 	installationsForJobs := []installationStruct{}
-	for _, githubInstallation := range githubInstallations {
+	for _, githubAppInstallation := range githubAppInstallations {
 		repositories := []renovateRepository{}
-		for _, repository := range githubInstallation.Repositories {
+		for _, repository := range githubAppInstallation.Repositories {
 			branch, ok := componentUrlToBranchMap[repository.GetHTMLURL()]
 			// Filter repositories with installed GH App but missing Component
 			if !ok {
@@ -171,8 +171,8 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		installationsForJobs = append(installationsForJobs,
 			installationStruct{
-				id:           int(githubInstallation.ID),
-				token:        githubInstallation.Token,
+				id:           int(githubAppInstallation.ID),
+				token:        githubAppInstallation.Token,
 				repositories: repositories,
 			})
 	}

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -151,7 +151,7 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Match installed repositories with Components and get custom branch if defined
-	installationsForJobs := []installationStruct{}
+	installationsToUpdate := []installationStruct{}
 	for _, githubAppInstallation := range githubAppInstallations {
 		repositories := []renovateRepository{}
 		for _, repository := range githubAppInstallation.Repositories {
@@ -169,7 +169,7 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 				Repository:   repository.GetFullName(),
 			})
 		}
-		installationsForJobs = append(installationsForJobs,
+		installationsToUpdate = append(installationsToUpdate,
 			installationStruct{
 				id:           int(githubAppInstallation.ID),
 				token:        githubAppInstallation.Token,
@@ -188,13 +188,13 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 	} else {
 		installationPerJobInt = InstallationsPerJob
 	}
-	for i := 0; i < len(installationsForJobs); i += installationPerJobInt {
+	for i := 0; i < len(installationsToUpdate); i += installationPerJobInt {
 		end := i + installationPerJobInt
 
-		if end > len(installationsForJobs) {
-			end = len(installationsForJobs)
+		if end > len(installationsToUpdate) {
+			end = len(installationsToUpdate)
 		}
-		err = r.CreateRenovaterJob(ctx, installationsForJobs[i:end], slug)
+		err = r.CreateRenovaterJob(ctx, installationsToUpdate[i:end], slug)
 		if err != nil {
 			r.Log.Error(err, "failed to create a job")
 		}

--- a/controllers/git_tekton_resources_renovater_test.go
+++ b/controllers/git_tekton_resources_renovater_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 		_ = AfterEach(func() {
 			deleteBuildPipelineRunSelector(defaultSelector)
 			deleteJobs(buildServiceNamespaceName)
+			os.Unsetenv(InstallationsPerJobEnvName)
 		})
 
 		It("It should not trigger job", func() {

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -42,8 +42,9 @@ type GithubClient struct {
 }
 
 type ApplicationInstallation struct {
-	Token          string
-	InstallationID int64
+	Token        string
+	ID           int64
+	Repositories []*github.Repository
 }
 
 func newGithubClient(accessToken string) *GithubClient {
@@ -153,9 +154,15 @@ func getInstallations(appId int64, privateKeyPem []byte) ([]ApplicationInstallat
 				// TODO analyze the error
 				continue
 			}
+			installationClient := NewGithubClient(token.GetToken())
+			repositoriesList, _, err := installationClient.client.Apps.ListRepos(context.Background(), &github.ListOptions{})
+			if err != nil {
+				continue
+			}
 			appInstallations = append(appInstallations, ApplicationInstallation{
-				Token:          token.GetToken(),
-				InstallationID: *val.ID,
+				Token:        token.GetToken(),
+				ID:           *val.ID,
+				Repositories: repositoriesList.Repositories,
 			})
 		}
 		if resp.NextPage == 0 {


### PR DESCRIPTION
- Do not go via all repositories available to GitHub app but process only repositories which match to component
- Separate configuration per installation
- [STONEBLD-915](https://issues.redhat.com//browse/STONEBLD-915): respect baseBranch based on Component revision