### PR TITLE
Fix test: add missing mock

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -561,6 +561,7 @@ var _ = Describe("Component initial build controller", func() {
 			github.NewGithubClient = func(accessToken string) *github.GithubClient { return nil }
 			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) { return "", nil }
 			github.SetupPaCWebhook = func(g *github.GithubClient, webhookUrl, webhookSecret, owner, repository string) error { return nil }
+			github.IsAppInstalledIntoRepository = func(g *github.GithubClient, owner, repository string) (bool, error) { return true, nil }
 			gitlab.EnsurePaCMergeRequest = func(g *gitlab.GitlabClient, d *gitlab.PaCMergeRequestData) (string, error) { return "", nil }
 			gitlab.SetupPaCWebhook = func(g *gitlab.GitlabClient, projectPath, webhookUrl, webhookSecret string) error { return nil }
 		})


### PR DESCRIPTION
Without this mock, when running "Test Pipelines as Code build clean up" solely, test "should successfully submit PR with PaC definitions removal using GitHub application" will panic eventually due to ghclient variable references nil.