### PR TITLE
STONEBLD-818:Intergate Image Controller operator

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -327,7 +327,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Check if Pipelines as Code workflow enabled
 	if val, exists := component.Annotations[PaCProvisionAnnotationName]; exists {
-		if val != PaCProvisionRequestedAnnotationValue {
+		if val != PaCProvisionRequestedAnnotationValue && !saUpdated {
 			if !(val == PaCProvisionDoneAnnotationValue || val == PaCProvisionErrorAnnotationValue) {
 				message := fmt.Sprintf(
 					"Unexpected value \"%s\" for \"%s\" annotation. Use \"%s\" value to do Pipeline as Code provision for the Component",

--- a/controllers/component_build_controller_common.go
+++ b/controllers/component_build_controller_common.go
@@ -80,7 +80,7 @@ func (r *ComponentBuildReconciler) GetPipelineForComponent(ctx context.Context, 
 
 func (r *ComponentBuildReconciler) ensurePipelineServiceAccount(ctx context.Context, namespace string) (*corev1.ServiceAccount, error) {
 	pipelinesServiceAccount := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: "pipeline", Namespace: namespace}, pipelinesServiceAccount)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: buildPipelineServiceAccountName, Namespace: namespace}, pipelinesServiceAccount)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			r.Log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", buildPipelineServiceAccountName, namespace))
@@ -102,41 +102,62 @@ func (r *ComponentBuildReconciler) ensurePipelineServiceAccount(ctx context.Cont
 	return pipelinesServiceAccount, nil
 }
 
-func (r *ComponentBuildReconciler) linkImageRegistrySecretToServiceAccount(ctx context.Context, imageRepo, imageRepoSecretName string, serviceAccount *corev1.ServiceAccount) (bool, error) {
+func (r *ComponentBuildReconciler) linkSecretToServiceAccount(ctx context.Context, secretName, serviceAccountName, namespace string, isPullSecret bool) (bool, error) {
 	log := r.Log
 
-	// Ensure that image repo secret is annotated to make it respected by Tekton
+	if secretName == "" {
+		// The secret is empty, no updates needed
+		return false, nil
+	}
 
-	// quay.io/userlogin/image:tag => https://quay.io
-	expectedTektonAnnotationValue := "https://" + strings.Split(imageRepo, "/")[0]
-
-	dockerSecret := corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: imageRepoSecretName, Namespace: serviceAccount.Namespace}, &dockerSecret)
+	serviceAccount := &corev1.ServiceAccount{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: namespace}, serviceAccount)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("Secret %s is missing", imageRepoSecretName))
-		return false, boerrors.NewBuildOpError(boerrors.EComponentImageRegistrySecretMissing, err)
-	}
-	if dockerSecret.Annotations == nil {
-		dockerSecret.Annotations = map[string]string{}
-	}
-	// We can always use 0 index because the component uses only one image repository
-	if dockerSecret.Annotations["tekton.dev/docker-0"] != expectedTektonAnnotationValue {
-		dockerSecret.Annotations["tekton.dev/docker-0"] = expectedTektonAnnotationValue
-		if err := r.Client.Update(ctx, &dockerSecret); err != nil {
-			log.Error(err, fmt.Sprintf("Failed to annotate %s secret with tekton annotation", imageRepoSecretName))
-			return false, err
+		if errors.IsNotFound(err) {
+			return false, nil
 		}
+		r.Log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", serviceAccountName, namespace))
+		return false, err
+	}
+
+	isNewSecretLinked := false
+
+	shouldAddLink := true
+	for _, secret := range serviceAccount.Secrets {
+		if secret.Name == secretName {
+			// The secret is present in the service account, no updates needed
+			shouldAddLink = false
+			break
+		}
+	}
+	if shouldAddLink {
+		serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: secretName, Namespace: namespace})
+	}
+	isNewSecretLinked = shouldAddLink
+
+	if isPullSecret {
+		shouldAddLink = true
+		for _, secret := range serviceAccount.ImagePullSecrets {
+			if secret.Name == secretName {
+				// The secret is present in the service account, no updates needed
+				shouldAddLink = false
+				break
+			}
+		}
+		if shouldAddLink {
+			serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+		}
+		isNewSecretLinked = isNewSecretLinked || shouldAddLink
 	}
 
 	// Update service account if needed
-	updateRequired := updateServiceAccountConfigIfSecretNotLinked(dockerSecret.Name, serviceAccount)
-	if updateRequired {
-		err = r.Client.Update(ctx, serviceAccount)
+	if isNewSecretLinked {
+		err := r.Client.Update(ctx, serviceAccount)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to update service account %s", serviceAccount.Name))
 			return false, err
 		}
-		log.Info(fmt.Sprintf("Service Account %s updated with image registry secret %s", serviceAccount.Name, dockerSecret.Name))
+		log.Info(fmt.Sprintf("Service Account %s updated with secret %s", serviceAccount.Name, secretName))
 		return true, nil
 	}
 	return false, nil
@@ -144,47 +165,64 @@ func (r *ComponentBuildReconciler) linkImageRegistrySecretToServiceAccount(ctx c
 
 // unlinkSecretFromServiceAccount ensures that the given secret is not linked with the provided service account.
 // Returns true if the secret was unlinked, false if the link didn't exist.
-func (r *ComponentBuildReconciler) unlinkSecretFromServiceAccount(ctx context.Context, secretName string, serviceAccount *corev1.ServiceAccount) (bool, error) {
-	index := -1
-	for i, credentialSecret := range serviceAccount.Secrets {
-		if credentialSecret.Name == secretName {
-			index = i
+func (r *ComponentBuildReconciler) unlinkSecretFromServiceAccount(ctx context.Context, secretNameToRemove, serviceAccountName, namespace string) (bool, error) {
+	serviceAccount := &corev1.ServiceAccount{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: namespace}, serviceAccount)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		r.Log.Error(err, fmt.Sprintf("Failed to read service account %s in namespace %s", serviceAccountName, namespace))
+		return false, err
+	}
+
+	isSecretUnlinked := false
+	// Remove secret from secrets list
+	for index, credentialSecret := range serviceAccount.Secrets {
+		if credentialSecret.Name == secretNameToRemove {
+			secrets := make([]corev1.ObjectReference, 0, len(serviceAccount.Secrets))
+			if len(serviceAccount.Secrets) != 1 {
+				secrets = append(secrets, serviceAccount.Secrets[:index]...)
+				secrets = append(secrets, serviceAccount.Secrets[index+1:]...)
+			}
+			serviceAccount.Secrets = secrets
+			isSecretUnlinked = true
 			break
 		}
 	}
-	if index != -1 {
-		secrets := make([]corev1.ObjectReference, 0, len(serviceAccount.Secrets))
-		if len(serviceAccount.Secrets) != 1 {
-			secrets = append(secrets, serviceAccount.Secrets[:index]...)
-			secrets = append(secrets, serviceAccount.Secrets[index+1:]...)
+	// Remove secret from pull secrets list
+	for index, pullSecret := range serviceAccount.ImagePullSecrets {
+		if pullSecret.Name == secretNameToRemove {
+			secrets := make([]corev1.LocalObjectReference, 0, len(serviceAccount.ImagePullSecrets))
+			if len(serviceAccount.Secrets) != 1 {
+				secrets = append(secrets, serviceAccount.ImagePullSecrets[:index]...)
+				secrets = append(secrets, serviceAccount.ImagePullSecrets[index+1:]...)
+			}
+			serviceAccount.ImagePullSecrets = secrets
+			isSecretUnlinked = true
+			break
 		}
-		serviceAccount.Secrets = secrets
+	}
 
+	if isSecretUnlinked {
 		if err := r.Client.Update(ctx, serviceAccount); err != nil {
 			r.Log.Error(err, fmt.Sprintf("Unable to update pipeline service account %v", serviceAccount))
 			return false, err
 		}
-		r.Log.Info(fmt.Sprintf("Removed %s secret link from %s service account", secretName, serviceAccount.Name))
-		return true, nil
+		r.Log.Info(fmt.Sprintf("Removed %s secret link from %s service account", secretNameToRemove, serviceAccount.Name))
 	}
-	return false, nil
+	return isSecretUnlinked, nil
 }
 
-func updateServiceAccountConfigIfSecretNotLinked(secretName string, serviceAccount *corev1.ServiceAccount) bool {
-	if secretName == "" {
-		// The secret is empty, no updates needed
-		return false
+func getContainerImageRepositoryForComponent(component *appstudiov1alpha1.Component) string {
+	if component.Spec.ContainerImage != "" {
+		return getContainerImageRepository(component.Spec.ContainerImage)
 	}
-	for _, credentialSecret := range serviceAccount.Secrets {
-		if credentialSecret.Name == secretName {
-			// The secret is present in the service account, no updates needed
-			return false
-		}
+	imageRepo, _, err := getComponentImageRepoAndSecretNameFromImageAnnotation(component)
+	if err == nil && imageRepo != "" {
+		return imageRepo
 	}
-
-	// Add the secret to the service account and return that update is needed
-	serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{Name: secretName})
-	return true
+	return ""
 }
 
 // getContainerImageRepository removes tag or SHA has from container image reference

--- a/controllers/component_build_controller_common.go
+++ b/controllers/component_build_controller_common.go
@@ -114,7 +114,7 @@ func (r *ComponentBuildReconciler) linkImageRegistrySecretToServiceAccount(ctx c
 	err := r.Client.Get(ctx, types.NamespacedName{Name: imageRepoSecretName, Namespace: serviceAccount.Namespace}, &dockerSecret)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Secret %s is missing", imageRepoSecretName))
-		return false, boerrors.NewBuildOpError(boerrors.EComponentDockerSecretMissing, err)
+		return false, boerrors.NewBuildOpError(boerrors.EComponentImageRegistrySecretMissing, err)
 	}
 	if dockerSecret.Annotations == nil {
 		dockerSecret.Annotations = map[string]string{}

--- a/controllers/component_build_controller_common.go
+++ b/controllers/component_build_controller_common.go
@@ -136,7 +136,7 @@ func (r *ComponentBuildReconciler) linkImageRegistrySecretToServiceAccount(ctx c
 			log.Error(err, fmt.Sprintf("Unable to update service account %s", serviceAccount.Name))
 			return false, err
 		}
-		log.Info(fmt.Sprintf("Service Account %s updated with image secret %s", serviceAccount.Name, dockerSecret.Name))
+		log.Info(fmt.Sprintf("Service Account %s updated with image registry secret %s", serviceAccount.Name, dockerSecret.Name))
 		return true, nil
 	}
 	return false, nil

--- a/controllers/component_build_controller_common.go
+++ b/controllers/component_build_controller_common.go
@@ -136,7 +136,7 @@ func (r *ComponentBuildReconciler) linkImageRegistrySecretToServiceAccount(ctx c
 			log.Error(err, fmt.Sprintf("Unable to update service account %s", serviceAccount.Name))
 			return false, err
 		}
-		log.Info(fmt.Sprintf("Service Account %s updated with image secret", serviceAccount.Name))
+		log.Info(fmt.Sprintf("Service Account %s updated with image secret %s", serviceAccount.Name, dockerSecret.Name))
 		return true, nil
 	}
 	return false, nil

--- a/controllers/component_build_controller_common.go
+++ b/controllers/component_build_controller_common.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	buildappstudiov1alpha1 "github.com/redhat-appstudio/build-service/api/v1alpha1"
+	"github.com/redhat-appstudio/build-service/pkg/boerrors"
+	pipelineselector "github.com/redhat-appstudio/build-service/pkg/pipeline-selector"
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetPipelineForComponent searches for the build pipeline to use on the component.
+func (r *ComponentBuildReconciler) GetPipelineForComponent(ctx context.Context, component *appstudiov1alpha1.Component) (*tektonapi.PipelineRef, []tektonapi.Param, error) {
+	var pipelineSelectors []buildappstudiov1alpha1.BuildPipelineSelector
+	pipelineSelector := &buildappstudiov1alpha1.BuildPipelineSelector{}
+
+	pipelineSelectorKeys := []types.NamespacedName{
+		// First try specific config for the application
+		{Namespace: component.Namespace, Name: component.Spec.Application},
+		// Second try namespaced config
+		{Namespace: component.Namespace, Name: buildPipelineSelectorResourceName},
+		// Finally try global config
+		{Namespace: buildServiceNamespaceName, Name: buildPipelineSelectorResourceName},
+	}
+
+	for _, pipelineSelectorKey := range pipelineSelectorKeys {
+		if err := r.Client.Get(ctx, pipelineSelectorKey, pipelineSelector); err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+			// The config is not found, try the next one in the hierarchy
+		} else {
+			pipelineSelectors = append(pipelineSelectors, *pipelineSelector)
+		}
+	}
+
+	if len(pipelineSelectors) > 0 {
+		pipelineRef, pipelineParams, err := pipelineselector.SelectPipelineForComponent(component, pipelineSelectors)
+		if err != nil {
+			return nil, nil, err
+		}
+		if pipelineRef != nil {
+			return pipelineRef, pipelineParams, nil
+		}
+	}
+
+	// Fallback to the default pipeline
+	return &tektonapi.PipelineRef{
+		Name:   defaultPipelineName,
+		Bundle: defaultPipelineBundle,
+	}, nil, nil
+}
+
+// getImageRepositoryForComponent returns repository for the component's images.
+func getImageRepositoryForComponent(component *appstudiov1alpha1.Component) (string, error) {
+	imageRepo, _, err := getComponentImageRepoAndSecretNameFromImageAnnotation(component)
+	if err != nil {
+		return "", err
+	}
+	if imageRepo == "" {
+		imageRepo = getContainerImageRepository(component.Spec.ContainerImage)
+	}
+	return imageRepo, nil
+}
+
+// getContainerImageRepository removes tag or SHA has from container image reference
+func getContainerImageRepository(image string) string {
+	if strings.Contains(image, "@") {
+		// registry.io/user/image@sha256:586ab...d59a
+		return strings.Split(image, "@")[0]
+	}
+	// registry.io/user/image:tag
+	return strings.Split(image, ":")[0]
+}
+
+// getComponentImageRepoAndSecretNameFromImageAnnotation parses image.redhat.com/image annotation
+// for image repository and secret name to access it.
+// If image.redhat.com/generate is not set, the procedure returns empty values.
+func getComponentImageRepoAndSecretNameFromImageAnnotation(component *appstudiov1alpha1.Component) (string, string, error) {
+	type RepositoryInfo struct {
+		Image  string `json:"image"`
+		Secret string `json:"secret"`
+	}
+
+	var repoInfo RepositoryInfo
+	if _, exists := component.Annotations[ImageRepoGenerateAnnotationName]; exists {
+		imageRepoDataJson := component.Annotations[ImageRepoAnnotationName]
+		if err := json.Unmarshal([]byte(imageRepoDataJson), &repoInfo); err != nil {
+			return "", "", boerrors.NewBuildOpError(boerrors.EFailedToParseImageAnnotation, err)
+		}
+		return repoInfo.Image, repoInfo.Secret, nil
+	}
+	return "", "", nil
+}
+
+// mergeAndSortTektonParams merges additional params into existing params by adding new or replacing existing values.
+func mergeAndSortTektonParams(existedParams, additionalParams []tektonapi.Param) []tektonapi.Param {
+	var params []tektonapi.Param
+	paramsMap := make(map[string]tektonapi.Param)
+	for _, p := range existedParams {
+		paramsMap[p.Name] = p
+	}
+	for _, p := range additionalParams {
+		paramsMap[p.Name] = p
+	}
+	for _, v := range paramsMap {
+		params = append(params, v)
+	}
+	sort.Slice(params, func(i, j int) bool {
+		return params[i].Name < params[j].Name
+	})
+	return params
+}
+
+func generateVolumeClaimTemplate() *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				"ReadWriteOnce",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"storage": resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}
+
+func getPathContext(gitContext, dockerfileContext string) string {
+	if gitContext == "" && dockerfileContext == "" {
+		return ""
+	}
+	separator := string(filepath.Separator)
+	path := filepath.Join(gitContext, dockerfileContext)
+	path = filepath.Clean(path)
+	path = strings.TrimPrefix(path, separator)
+	return path
+}

--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -22,8 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -36,16 +34,13 @@ import (
 	"github.com/redhat-appstudio/application-service/gitops"
 	gitopsprepare "github.com/redhat-appstudio/application-service/gitops/prepare"
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
-	buildappstudiov1alpha1 "github.com/redhat-appstudio/build-service/api/v1alpha1"
 	"github.com/redhat-appstudio/build-service/pkg/boerrors"
 	"github.com/redhat-appstudio/build-service/pkg/github"
 	"github.com/redhat-appstudio/build-service/pkg/gitlab"
-	pipelineselector "github.com/redhat-appstudio/build-service/pkg/pipeline-selector"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	oci "github.com/tektoncd/pipeline/pkg/remote/oci"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -746,7 +741,11 @@ func generatePaCPipelineRunForComponent(
 		"pipelines.appstudio.openshift.io/type": "build",
 	}
 
-	imageRepo := getContainerImageRepository(component.Spec.ContainerImage)
+	imageRepo, err := getImageRepositoryForComponent(component)
+	if err != nil {
+		return nil, err
+	}
+
 	var pipelineName string
 	var proposedImage string
 	if onPull {
@@ -805,27 +804,6 @@ func generatePaCPipelineRunForComponent(
 	return pipelineRun, nil
 }
 
-// getContainerImageRepository removes tag or SHA has from container image reference
-func getContainerImageRepository(image string) string {
-	if strings.Contains(image, "@") {
-		// registry.io/user/image@sha256:586ab...d59a
-		return strings.Split(image, "@")[0]
-	}
-	// registry.io/user/image:tag
-	return strings.Split(image, ":")[0]
-}
-
-func getPathContext(gitContext, dockerfileContext string) string {
-	if gitContext == "" && dockerfileContext == "" {
-		return ""
-	}
-	separator := string(filepath.Separator)
-	path := filepath.Join(gitContext, dockerfileContext)
-	path = filepath.Clean(path)
-	path = strings.TrimPrefix(path, separator)
-	return path
-}
-
 func createWorkspaceBinding(pipelineWorkspaces []tektonapi.PipelineWorkspaceDeclaration) []tektonapi.WorkspaceBinding {
 	pipelineRunWorkspaces := []tektonapi.WorkspaceBinding{}
 	for _, workspace := range pipelineWorkspaces {
@@ -845,82 +823,6 @@ func createWorkspaceBinding(pipelineWorkspaces []tektonapi.PipelineWorkspaceDecl
 		}
 	}
 	return pipelineRunWorkspaces
-}
-
-func generateVolumeClaimTemplate() *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
-		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				"ReadWriteOnce",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					"storage": resource.MustParse("1Gi"),
-				},
-			},
-		},
-	}
-}
-
-// mergeAndSortTektonParams merges additional params into existing params by adding new or replacing existing values.
-func mergeAndSortTektonParams(existedParams, additionalParams []tektonapi.Param) []tektonapi.Param {
-	var params []tektonapi.Param
-	paramsMap := make(map[string]tektonapi.Param)
-	for _, p := range existedParams {
-		paramsMap[p.Name] = p
-	}
-	for _, p := range additionalParams {
-		paramsMap[p.Name] = p
-	}
-	for _, v := range paramsMap {
-		params = append(params, v)
-	}
-	sort.Slice(params, func(i, j int) bool {
-		return params[i].Name < params[j].Name
-	})
-	return params
-}
-
-// GetPipelineForComponent searches for the build pipeline to use on the component.
-func (r *ComponentBuildReconciler) GetPipelineForComponent(ctx context.Context, component *appstudiov1alpha1.Component) (*tektonapi.PipelineRef, []tektonapi.Param, error) {
-	var pipelineSelectors []buildappstudiov1alpha1.BuildPipelineSelector
-	pipelineSelector := &buildappstudiov1alpha1.BuildPipelineSelector{}
-
-	pipelineSelectorKeys := []types.NamespacedName{
-		// First try specific config for the application
-		{Namespace: component.Namespace, Name: component.Spec.Application},
-		// Second try namespaced config
-		{Namespace: component.Namespace, Name: buildPipelineSelectorResourceName},
-		// Finally try global config
-		{Namespace: buildServiceNamespaceName, Name: buildPipelineSelectorResourceName},
-	}
-
-	for _, pipelineSelectorKey := range pipelineSelectorKeys {
-		if err := r.Client.Get(ctx, pipelineSelectorKey, pipelineSelector); err != nil {
-			if !errors.IsNotFound(err) {
-				return nil, nil, err
-			}
-			// The config is not found, try the next one in the hierarchy
-		} else {
-			pipelineSelectors = append(pipelineSelectors, *pipelineSelector)
-		}
-	}
-
-	if len(pipelineSelectors) > 0 {
-		pipelineRef, pipelineParams, err := pipelineselector.SelectPipelineForComponent(component, pipelineSelectors)
-		if err != nil {
-			return nil, nil, err
-		}
-		if pipelineRef != nil {
-			return pipelineRef, pipelineParams, nil
-		}
-	}
-
-	// Fallback to the default pipeline
-	return &tektonapi.PipelineRef{
-		Name:   defaultPipelineName,
-		Bundle: defaultPipelineBundle,
-	}, nil, nil
 }
 
 // retrievePipelineSpec retrieves pipeline definition with given name from the given bundle.

--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -741,10 +741,7 @@ func generatePaCPipelineRunForComponent(
 		"pipelines.appstudio.openshift.io/type": "build",
 	}
 
-	imageRepo, err := getImageRepositoryForComponent(component)
-	if err != nil {
-		return nil, err
-	}
+	imageRepo := getContainerImageRepository(component.Spec.ContainerImage)
 
 	var pipelineName string
 	var proposedImage string

--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -741,7 +741,7 @@ func generatePaCPipelineRunForComponent(
 		"pipelines.appstudio.openshift.io/type": "build",
 	}
 
-	imageRepo := getContainerImageRepository(component.Spec.ContainerImage)
+	imageRepo := getContainerImageRepositoryForComponent(component)
 
 	var pipelineName string
 	var proposedImage string
@@ -828,7 +828,7 @@ func retrievePipelineSpec(bundleUri, pipelineName string) (*tektonapi.PipelineSp
 	var err error
 	resolver := oci.NewResolver(bundleUri, authn.DefaultKeychain)
 
-	if obj, _, err = resolver.Get(context.TODO(), "pipeline", pipelineName); err != nil {
+	if obj, _, err = resolver.Get(context.TODO(), buildPipelineServiceAccountName, pipelineName); err != nil {
 		return nil, err
 	}
 	pipelineSpecObj, ok := obj.(tektonapi.PipelineObject)

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Component initial build controller", func() {
 		pacSecretKey           = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
 		namespacePaCSecretKey  = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
 		webhookSecretKey       = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
-		imageRegistrySecretKey = types.NamespacedName{Name: imageRegistryUserSecretName, Namespace: HASAppNamespace}
+		imageRegistrySecretKey = types.NamespacedName{Name: imageRepoUserSecretName, Namespace: HASAppNamespace}
 	)
 
 	Context("Test Pipelines as Code build preparation", func() {
@@ -552,10 +552,10 @@ var _ = Describe("Component initial build controller", func() {
 			setComponentDevfileModel(resourceKey)
 		})
 
-		It("should be able to switch betweeen internal and user provided image registry", func() {
+		It("should be able to switch between internal and user provided image registry", func() {
 			usersImageRepo := "registry.io/user/image"
-			generatedImageRepo := "quay.io/appstudio/image"
-			generatedImageRepoSecretName := "image-repo-secret"
+			generatedImageRepo := "quay.io/appstudio/generated-image"
+			generatedImageRepoSecretName := "generated-image-repo-secret"
 			generatedImageRepoSecretKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: generatedImageRepoSecretName}
 			pipelineSAKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: "pipeline"}
 
@@ -582,9 +582,9 @@ var _ = Describe("Component initial build controller", func() {
 					if secret.Name == generatedImageRepoSecretName {
 						isImageRegistryGeneratedSecretLinked = true
 						secretName = generatedImageRepoSecretName
-					} else if secret.Name == imageRegistryUserSecretName {
+					} else if secret.Name == imageRepoUserSecretName {
 						isImageRegistryUserSecretLinked = true
-						secretName = imageRegistryUserSecretName
+						secretName = imageRepoUserSecretName
 					}
 				}
 				Expect(isImageRegistryGeneratedSecretLinked).To(Equal(generatedSecret))
@@ -639,6 +639,8 @@ var _ = Describe("Component initial build controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			checkSecretLinkToServiceAccount(true)
+			// Wait for all reconcilations finihed to avoid changing callbacks in the middle of a reconcile.
+			time.Sleep(2 * time.Second)
 
 			// Switch to user provided image repository
 

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -915,7 +915,7 @@ var _ = Describe("Component initial build controller", func() {
 				switch p.Name {
 				case "output-image":
 					Expect(p.Value.StringVal).ToNot(BeEmpty())
-					Expect(strings.HasPrefix(p.Value.StringVal, "docker.io/foo/customized:"+HASCompName+"-initial-build-"))
+					Expect(strings.HasPrefix(p.Value.StringVal, "docker.io/foo/customized:"+HASCompName+"-build-"))
 				case "git-url":
 					Expect(p.Value.StringVal).To(Equal(SampleRepoLink))
 				case "revision":

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -18,9 +18,10 @@ package controllers
 
 import (
 	"fmt"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,11 +79,12 @@ var _ = Describe("Component initial build controller", func() {
 
 	var (
 		// All related to the component resources have the same key (but different type)
-		resourceKey           = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
-		pacRouteKey           = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
-		pacSecretKey          = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
-		namespacePaCSecretKey = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
-		webhookSecretKey      = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
+		resourceKey            = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+		pacRouteKey            = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
+		pacSecretKey           = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
+		namespacePaCSecretKey  = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
+		webhookSecretKey       = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
+		imageRegistrySecretKey = types.NamespacedName{Name: imageRegistryUserSecretName, Namespace: HASAppNamespace}
 	)
 
 	Context("Test Pipelines as Code build preparation", func() {
@@ -96,6 +98,7 @@ var _ = Describe("Component initial build controller", func() {
 				"github-private-key":    githubAppPrivateKey,
 			}
 			createSecret(pacSecretKey, pacSecretData)
+			createSecret(imageRegistrySecretKey, map[string]string{})
 
 			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) { return nil, nil }
 			github.NewGithubClient = func(accessToken string) *github.GithubClient { return nil }

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -79,12 +79,11 @@ var _ = Describe("Component initial build controller", func() {
 
 	var (
 		// All related to the component resources have the same key (but different type)
-		resourceKey            = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
-		pacRouteKey            = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
-		pacSecretKey           = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
-		namespacePaCSecretKey  = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
-		webhookSecretKey       = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
-		imageRegistrySecretKey = types.NamespacedName{Name: imageRepoUserSecretName, Namespace: HASAppNamespace}
+		resourceKey           = types.NamespacedName{Name: HASCompName, Namespace: HASAppNamespace}
+		pacRouteKey           = types.NamespacedName{Name: pipelinesAsCodeRouteName, Namespace: pipelinesAsCodeNamespace}
+		pacSecretKey          = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: buildServiceNamespaceName}
+		namespacePaCSecretKey = types.NamespacedName{Name: gitopsprepare.PipelinesAsCodeSecretName, Namespace: HASAppNamespace}
+		webhookSecretKey      = types.NamespacedName{Name: gitops.PipelinesAsCodeWebhooksSecretName, Namespace: HASAppNamespace}
 	)
 
 	Context("Test Pipelines as Code build preparation", func() {
@@ -98,7 +97,6 @@ var _ = Describe("Component initial build controller", func() {
 				"github-private-key":    githubAppPrivateKey,
 			}
 			createSecret(pacSecretKey, pacSecretData)
-			createSecret(imageRegistrySecretKey, map[string]string{})
 
 			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) { return nil, nil }
 			github.NewGithubClient = func(accessToken string) *github.GithubClient { return nil }
@@ -536,6 +534,7 @@ var _ = Describe("Component initial build controller", func() {
 				return repoDefaultBranch, nil
 			}
 
+			isCreatePaCPullRequestInvoked := false
 			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
 				Expect(d.BaseBranch).To(Equal(repoDefaultBranch))
 				for _, file := range d.Files {
@@ -546,18 +545,25 @@ var _ = Describe("Component initial build controller", func() {
 					targetBranches := prYaml.Annotations["pipelinesascode.tekton.dev/on-target-branch"]
 					Expect(targetBranches).To(Equal(fmt.Sprintf("[%s]", repoDefaultBranch)))
 				}
+				isCreatePaCPullRequestInvoked = true
 				return "url", nil
 			}
 
 			setComponentDevfileModel(resourceKey)
+
+			Eventually(func() bool {
+				return isCreatePaCPullRequestInvoked
+			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("should be able to switch between internal and user provided image registry", func() {
-			usersImageRepo := "registry.io/user/image"
+		It("should link auto generated image repository secret to pipeline service accoount", func() {
+			deleteComponent(resourceKey)
+
+			userImageRepo := "docker.io/user/image"
 			generatedImageRepo := "quay.io/appstudio/generated-image"
 			generatedImageRepoSecretName := "generated-image-repo-secret"
 			generatedImageRepoSecretKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: generatedImageRepoSecretName}
-			pipelineSAKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: "pipeline"}
+			pipelineSAKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: buildPipelineServiceAccountName}
 
 			checkPROutputImage := func(fileContent []byte, expectedImageRepo string) {
 				var prYaml v1beta1.PipelineRun
@@ -572,62 +578,43 @@ var _ = Describe("Component initial build controller", func() {
 				Expect(outoutImage).ToNot(BeEmpty())
 				Expect(outoutImage).To(ContainSubstring(expectedImageRepo))
 			}
-			checkSecretLinkToServiceAccount := func(generatedSecret bool) {
-				pipelineSA := &corev1.ServiceAccount{}
-				Expect(k8sClient.Get(ctx, pipelineSAKey, pipelineSA)).To(Succeed())
-				var secretName string
-				isImageRegistryGeneratedSecretLinked := false
-				isImageRegistryUserSecretLinked := false
-				for _, secret := range pipelineSA.Secrets {
-					if secret.Name == generatedImageRepoSecretName {
-						isImageRegistryGeneratedSecretLinked = true
-						secretName = generatedImageRepoSecretName
-					} else if secret.Name == imageRepoUserSecretName {
-						isImageRegistryUserSecretLinked = true
-						secretName = imageRepoUserSecretName
-					}
-				}
-				Expect(isImageRegistryGeneratedSecretLinked).To(Equal(generatedSecret))
-				Expect(isImageRegistryUserSecretLinked).ToNot(Equal(generatedSecret))
 
-				secretKey := types.NamespacedName{Namespace: pipelineSA.Namespace, Name: secretName}
-				secret := &corev1.Secret{}
-				Expect(k8sClient.Get(ctx, secretKey, secret)).To(Succeed())
-				Expect(secret.Annotations["tekton.dev/docker-0"]).ToNot(BeEmpty())
-			}
-
+			isCreatePaCPullRequestInvoked := false
 			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
 				defer GinkgoRecover()
-				Fail("Should not create PR if container image is not set")
-				return "", nil
+				checkPROutputImage(d.Files[0].Content, userImageRepo)
+				isCreatePaCPullRequestInvoked = true
+				return "url", nil
 			}
-			deleteComponent(resourceKey)
 
-			// Create a component with empty ContainerImage
-			componentData := getSampleComponentData(resourceKey)
-			componentData.Spec.ContainerImage = ""
-			createComponentForPaCBuild(componentData)
+			// Create a component with user's ContainerImage
+			component := getSampleComponentData(resourceKey)
+			component.Spec.ContainerImage = userImageRepo
+			createComponentForPaCBuild(component)
 			setComponentDevfileModel(resourceKey)
-			// Wait to make sure PR creation is not invoked
-			time.Sleep(time.Second)
+
+			Eventually(func() bool {
+				return isCreatePaCPullRequestInvoked
+			}, timeout, interval).Should(BeTrue())
 
 			createSecret(generatedImageRepoSecretKey, nil)
 			defer deleteSecret(generatedImageRepoSecretKey)
 
 			// Switch to generated image repository
 
-			isCreatePaCPullRequestInvoked := false
+			isCreatePaCPullRequestInvoked = false
 			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
 				defer GinkgoRecover()
 				checkPROutputImage(d.Files[0].Content, generatedImageRepo)
 				isCreatePaCPullRequestInvoked = true
-				return "url", nil
+				return "url2", nil
 			}
 
-			component := getComponent(resourceKey)
+			component = getComponent(resourceKey)
 			component.Annotations[ImageRepoGenerateAnnotationName] = "false"
 			component.Annotations[ImageRepoAnnotationName] =
 				fmt.Sprintf("{\"image\":\"%s\",\"secret\":\"%s\"}", generatedImageRepo, generatedImageRepoSecretName)
+			component.Spec.ContainerImage = generatedImageRepo
 			Expect(k8sClient.Update(ctx, component)).To(Succeed())
 
 			Eventually(func() bool {
@@ -638,32 +625,16 @@ var _ = Describe("Component initial build controller", func() {
 				return isCreatePaCPullRequestInvoked
 			}, timeout, interval).Should(BeTrue())
 
-			checkSecretLinkToServiceAccount(true)
-			// Wait for all reconcilations finihed to avoid changing callbacks in the middle of a reconcile.
-			time.Sleep(2 * time.Second)
-
-			// Switch to user provided image repository
-
-			isCreatePaCPullRequestInvoked = false
-			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) {
-				defer GinkgoRecover()
-				checkPROutputImage(d.Files[0].Content, usersImageRepo)
-				isCreatePaCPullRequestInvoked = true
-				return "url2", nil
+			pipelineSA := &corev1.ServiceAccount{}
+			Expect(k8sClient.Get(ctx, pipelineSAKey, pipelineSA)).To(Succeed())
+			isImageRegistryGeneratedSecretLinked := false
+			for _, secret := range pipelineSA.Secrets {
+				if secret.Name == generatedImageRepoSecretName {
+					isImageRegistryGeneratedSecretLinked = true
+					break
+				}
 			}
-
-			component = getComponent(resourceKey)
-			component.Spec.ContainerImage = usersImageRepo
-			Expect(k8sClient.Update(ctx, component)).To(Succeed())
-			Eventually(func() bool {
-				component = getComponent(resourceKey)
-				return component.Spec.ContainerImage == usersImageRepo
-			}, timeout, interval).Should(BeTrue())
-			Eventually(func() bool {
-				return isCreatePaCPullRequestInvoked
-			}, timeout, interval).Should(BeTrue())
-
-			checkSecretLinkToServiceAccount(false)
+			Expect(isImageRegistryGeneratedSecretLinked).To(BeTrue())
 		})
 	})
 
@@ -862,6 +833,90 @@ var _ = Describe("Component initial build controller", func() {
 			ensureComponentInitialBuildAnnotationState(resourceKey, true)
 		})
 
+		It("should submit initial build for private git repository", func() {
+			deleteComponent(resourceKey)
+
+			gitSecretKey := types.NamespacedName{Name: GitSecretName, Namespace: resourceKey.Namespace}
+			gitSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gitSecretKey.Name,
+					Namespace: gitSecretKey.Namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, gitSecret)).Should(Succeed())
+
+			// Create component that refers to the git secret
+			component := getSampleComponentData(resourceKey)
+			component.Spec.ContainerImage = "docker.io/foo/customized:default-test-component"
+			component.Spec.Secret = GitSecretName
+			Expect(k8sClient.Create(ctx, component)).Should(Succeed())
+			setComponentDevfileModel(resourceKey)
+
+			// Wait until all resources created
+			waitOneInitialPipelineRunCreated(resourceKey)
+			ensureComponentInitialBuildAnnotationState(resourceKey, true)
+
+			// Check that git credentials secret is annotated
+			Expect(k8sClient.Get(ctx, gitSecretKey, gitSecret)).Should(Succeed())
+			tektonGitAnnotation := gitSecret.ObjectMeta.Annotations["tekton.dev/git-0"]
+			Expect(tektonGitAnnotation).To(Equal("https://github.com"))
+
+			// Check that the pipeline service account has been linked with the Github authentication credentials
+			var pipelineSA corev1.ServiceAccount
+			pipelineSAKey := types.NamespacedName{Namespace: resourceKey.Namespace, Name: buildPipelineServiceAccountName}
+			Expect(k8sClient.Get(ctx, pipelineSAKey, &pipelineSA)).Should(Succeed())
+
+			secretFound := false
+			for _, secret := range pipelineSA.Secrets {
+				if secret.Name == GitSecretName {
+					secretFound = true
+					break
+				}
+			}
+			Expect(secretFound).To(BeTrue())
+
+			// Check the pipeline run and its resources
+			pipelineRuns := listComponentPipelineRuns(resourceKey)
+			Expect(len(pipelineRuns)).To(Equal(1))
+			pipelineRun := pipelineRuns[0]
+
+			Expect(pipelineRun.Labels[ApplicationNameLabelName]).To(Equal(HASAppName))
+			Expect(pipelineRun.Labels[ComponentNameLabelName]).To(Equal(HASCompName))
+
+			Expect(pipelineRun.Annotations["build.appstudio.redhat.com/pipeline_name"]).To(Equal(defaultPipelineName))
+			Expect(pipelineRun.Annotations["build.appstudio.redhat.com/bundle"]).To(Equal(defaultPipelineBundle))
+
+			Expect(pipelineRun.Spec.PipelineSpec).To(BeNil())
+
+			Expect(pipelineRun.Spec.PipelineRef).ToNot(BeNil())
+			Expect(pipelineRun.Spec.PipelineRef.Name).To(Equal(defaultPipelineName))
+			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultPipelineBundle))
+
+			Expect(pipelineRun.Spec.Params).ToNot(BeEmpty())
+			for _, p := range pipelineRun.Spec.Params {
+				switch p.Name {
+				case "output-image":
+					Expect(p.Value.StringVal).ToNot(BeEmpty())
+					Expect(strings.HasPrefix(p.Value.StringVal, "docker.io/foo/customized:"+HASCompName+"-build-"))
+				case "git-url":
+					Expect(p.Value.StringVal).To(Equal(SampleRepoLink))
+				case "revision":
+					Expect(p.Value.StringVal).To(Equal("main"))
+				}
+			}
+
+			Expect(pipelineRun.Spec.Workspaces).To(Not(BeEmpty()))
+			for _, w := range pipelineRun.Spec.Workspaces {
+				if w.Name == "workspace" {
+					Expect(w.VolumeClaimTemplate).NotTo(
+						Equal(nil), "PipelineRun should have its own volumeClaimTemplate.")
+				}
+			}
+
+			// Clean up
+			deleteSecret(gitSecretKey)
+		})
+
 		It("should not submit initial build if the component devfile model is not set", func() {
 			ensureNoPipelineRunsCreated(resourceKey)
 		})
@@ -902,153 +957,6 @@ var _ = Describe("Component initial build controller", func() {
 			ensureNoPipelineRunsCreated(resourceKey)
 		})
 
-		It("should submit initial build if a container image is set to default repo and starting with namespace tag", func() {
-			deleteComponent(resourceKey)
-
-			component := &appstudiov1alpha1.Component{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
-					Namespace: HASAppNamespace,
-				},
-				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName:  HASCompName,
-					Application:    HASAppName,
-					ContainerImage: gitops.GetDefaultImageRepo() + ":" + HASAppNamespace + "-tag",
-					Source: appstudiov1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-							GitSource: &appstudiov1alpha1.GitSource{
-								URL: SampleRepoLink,
-							},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-
-			setComponentDevfileModel(resourceKey)
-
-			waitOneInitialPipelineRunCreated(resourceKey)
-			ensureComponentInitialBuildAnnotationState(resourceKey, true)
-		})
-
-	})
-
-	Context("Check if initial build objects are created", func() {
-
-		var gitSecret *corev1.Secret
-
-		BeforeEach(func() {
-			// Pre-create git secret
-			gitSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      GitSecretName,
-					Namespace: HASAppNamespace,
-				},
-			}
-			Expect(k8sClient.Create(ctx, gitSecret)).Should(Succeed())
-			// Create component that refers to the git secret
-			component := &appstudiov1alpha1.Component{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "appstudio.redhat.com/v1alpha1",
-					Kind:       "Component",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      HASCompName,
-					Namespace: HASAppNamespace,
-				},
-				Spec: appstudiov1alpha1.ComponentSpec{
-					ComponentName:  HASCompName,
-					Application:    HASAppName,
-					Secret:         GitSecretName,
-					ContainerImage: "docker.io/foo/customized:default-test-component",
-					Source: appstudiov1alpha1.ComponentSource{
-						ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
-							GitSource: &appstudiov1alpha1.GitSource{
-								URL: SampleRepoLink,
-							},
-						},
-					},
-				},
-				Status: appstudiov1alpha1.ComponentStatus{
-					Devfile: getMinimalDevfile(),
-				},
-			}
-			Expect(k8sClient.Create(ctx, component)).Should(Succeed())
-		})
-
-		AfterEach(func() {
-			deleteComponentPipelineRuns(resourceKey)
-			deleteComponent(resourceKey)
-			Expect(k8sClient.Delete(ctx, gitSecret)).Should(Succeed())
-		})
-
-		It("should create build objects when image registry secret missing", func() {
-			setComponentDevfileModel(resourceKey)
-
-			// Wait until all resources created
-			waitOneInitialPipelineRunCreated(resourceKey)
-
-			// Check that git credentials secret is annotated
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: GitSecretName, Namespace: HASAppNamespace}, gitSecret)).Should(Succeed())
-			tektonGitAnnotation := gitSecret.ObjectMeta.Annotations["tekton.dev/git-0"]
-			Expect(tektonGitAnnotation).To(Equal("https://github.com"))
-
-			// Check that the pipeline service account has been linked with the Github authentication credentials
-			var pipelineSA corev1.ServiceAccount
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "pipeline", Namespace: HASAppNamespace}, &pipelineSA)).Should(Succeed())
-
-			secretFound := false
-			for _, secret := range pipelineSA.Secrets {
-				if secret.Name == GitSecretName {
-					secretFound = true
-					break
-				}
-			}
-			Expect(secretFound).To(BeTrue())
-
-			// Check the pipeline run and its resources
-			pipelineRuns := listComponentPipelineRuns(resourceKey)
-			Expect(len(pipelineRuns)).To(Equal(1))
-			pipelineRun := pipelineRuns[0]
-
-			Expect(pipelineRun.Labels[ApplicationNameLabelName]).To(Equal(HASAppName))
-			Expect(pipelineRun.Labels[ComponentNameLabelName]).To(Equal(HASCompName))
-
-			Expect(pipelineRun.Annotations["build.appstudio.redhat.com/pipeline_name"]).To(Equal(defaultPipelineName))
-			Expect(pipelineRun.Annotations["build.appstudio.redhat.com/bundle"]).To(Equal(defaultPipelineBundle))
-
-			Expect(pipelineRun.Spec.PipelineSpec).To(BeNil())
-
-			Expect(pipelineRun.Spec.PipelineRef).ToNot(BeNil())
-			Expect(pipelineRun.Spec.PipelineRef.Name).To(Equal(defaultPipelineName))
-			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultPipelineBundle))
-
-			Expect(pipelineRun.Spec.Params).ToNot(BeEmpty())
-			for _, p := range pipelineRun.Spec.Params {
-				switch p.Name {
-				case "output-image":
-					Expect(p.Value.StringVal).ToNot(BeEmpty())
-					Expect(strings.HasPrefix(p.Value.StringVal, "docker.io/foo/customized:"+HASCompName+"-build-"))
-				case "git-url":
-					Expect(p.Value.StringVal).To(Equal(SampleRepoLink))
-				case "revision":
-					Expect(p.Value.StringVal).To(Equal(""))
-				}
-			}
-
-			Expect(pipelineRun.Spec.Workspaces).To(Not(BeEmpty()))
-			for _, w := range pipelineRun.Spec.Workspaces {
-				if w.Name == "workspace" {
-					Expect(w.VolumeClaimTemplate).NotTo(
-						Equal(nil), "PipelineRun should have its own volumeClaimTemplate.")
-				}
-			}
-
-		})
 	})
 
 	Context("Resolve the correct build bundle during the component's creation", func() {

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -437,7 +437,7 @@ func TestUpdateServiceAccountIfSecretNotLinked(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := updateServiceAccountIfSecretNotLinked(tt.args.gitSecretName, tt.args.serviceAccount); got != tt.want {
+			if got := updateServiceAccountConfigIfSecretNotLinked(tt.args.gitSecretName, tt.args.serviceAccount); got != tt.want {
 				t.Errorf("UpdateServiceAccountIfSecretNotLinked() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -126,7 +126,7 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 				t.Errorf("generateInitialPipelineRunForComponent(): wrong pipeline parameter %s value", param.Name)
 			}
 		case "output-image":
-			if !strings.HasPrefix(param.Value.StringVal, "registry.io/username/image:initial-build-") {
+			if !strings.HasPrefix(param.Value.StringVal, "registry.io/username/image:build-") {
 				t.Errorf("generateInitialPipelineRunForComponent(): wrong pipeline parameter %s value", param.Name)
 			}
 		case "rebuild":

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -382,68 +382,6 @@ func TestGetGitProvider(t *testing.T) {
 	}
 }
 
-func TestUpdateServiceAccountIfSecretNotLinked(t *testing.T) {
-	type args struct {
-		gitSecretName  string
-		serviceAccount *corev1.ServiceAccount
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "present",
-			args: args{
-				gitSecretName: "present",
-				serviceAccount: &corev1.ServiceAccount{
-					Secrets: []corev1.ObjectReference{
-						{
-							Name: "present",
-						},
-					},
-				},
-			},
-			want: false, // since it was present, this implies the SA wasn't updated.
-		},
-		{
-			name: "not present",
-			args: args{
-				gitSecretName: "not-present",
-				serviceAccount: &corev1.ServiceAccount{
-					Secrets: []corev1.ObjectReference{
-						{
-							Name: "something-else",
-						},
-					},
-				},
-			},
-			want: true, // since it wasn't present, this implies the SA was updated.
-		},
-		{
-			name: "secretname is empty string",
-			args: args{
-				gitSecretName: "",
-				serviceAccount: &corev1.ServiceAccount{
-					Secrets: []corev1.ObjectReference{
-						{
-							Name: "present",
-						},
-					},
-				},
-			},
-			want: false, // since it wasn't present, this implies the SA was updated.
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := updateServiceAccountConfigIfSecretNotLinked(tt.args.gitSecretName, tt.args.serviceAccount); got != tt.want {
-				t.Errorf("UpdateServiceAccountIfSecretNotLinked() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestValidatePaCConfiguration(t *testing.T) {
 	const ghAppPrivateKeyStub = "-----BEGIN RSA PRIVATE KEY-----_key-content_-----END RSA PRIVATE KEY-----"
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 
 	svcAccount := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pipeline",
+			Name:      buildPipelineServiceAccountName,
 			Namespace: "default",
 		},
 	}

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -118,7 +118,7 @@ const (
 	// The secret with git credentials specified in component.Spec.Secret does not exist in the user's namespace.
 	EComponentGitSecretMissing BOErrorId = 201
 	// The secret with image registry credentials specified in 'image.redhat.com/image' annotation does not exist in the user's namespace.
-	EComponentDockerSecretMissing BOErrorId = 202
+	EComponentImageRegistrySecretMissing BOErrorId = 202
 )
 
 var boErrorMessages = map[BOErrorId]string{
@@ -142,7 +142,7 @@ var boErrorMessages = map[BOErrorId]string{
 	EGitLabTokenInsufficientScope: "GitLab access token does not have enough scope",
 	EGitLabTokenUnauthorized:      "Access token is unrecognizable by remote GitLab service",
 
-	EFailedToParseImageAnnotation: "Failed to parse image.redhat.com/image annotation value",
-	EComponentGitSecretMissing:    "Specified secret with git credential not found",
-	EComponentDockerSecretMissing: "Component image repository secret not found",
+	EFailedToParseImageAnnotation:        "Failed to parse image.redhat.com/image annotation value",
+	EComponentGitSecretMissing:           "Specified secret with git credential not found",
+	EComponentImageRegistrySecretMissing: "Component image repository secret not found",
 }

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -112,6 +112,13 @@ const (
 	EGitLabTokenUnauthorized BOErrorId = 90
 	// EGitLabTokenInsufficientScope the access token does not have sufficient scope and 403 is responded.
 	EGitLabTokenInsufficientScope BOErrorId = 91
+
+	// Value of 'image.redhat.com/image' component annotation is not a valid json or the json has invalid structure.
+	EFailedToParseImageAnnotation BOErrorId = 200
+	// The secret with git credentials specified in component.Spec.Secret does not exist in the user's namespace.
+	EComponentGitSecretMissing BOErrorId = 201
+	// The secret with image registry credentials specified in 'image.redhat.com/image' annotation does not exist in the user's namespace.
+	EComponentDockerSecretMissing BOErrorId = 202
 )
 
 var boErrorMessages = map[BOErrorId]string{
@@ -134,4 +141,8 @@ var boErrorMessages = map[BOErrorId]string{
 
 	EGitLabTokenInsufficientScope: "GitLab access token does not have enough scope",
 	EGitLabTokenUnauthorized:      "Access token is unrecognizable by remote GitLab service",
+
+	EFailedToParseImageAnnotation: "Failed to parse image.redhat.com/image annotation value",
+	EComponentGitSecretMissing:    "Specified secret with git credential not found",
+	EComponentDockerSecretMissing: "Component image repository secret not found",
 }


### PR DESCRIPTION
This PR integrates functionality provided by [Image Controller operator](https://github.com/redhat-appstudio/image-controller) into Build Service.

Generated by Image Controller operator image repository (it's data) is set in `image.redhat.com/image` annotation of the component. 
Build Service uses value from `component.Spec.ContainerImage`, but if it's not set, but the Image controller annotation is present, Build Service will use the image from `image.redhat.com/image`.

Image repository provided directly by the user is supported on the level it was supported before: the user should create a docker secret and link it to the `pipeline` service account.

Under the hood, Build Service adds/removes auto generated image registry secret to/from `pipeline` Service Account. To achieve clean up, a new finalizer `image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer` is added.

