### PR TITLE
test: Setup codecov to block PRs from getting merged if they decrease coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,14 @@
 comment: off
+
+ignore:
+  - "pkg/github"
+  - "pkg/gitlab"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1.5%
+        removed_code_behavior: adjust_base
+

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,6 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1.5%
+        threshold: 1%
         removed_code_behavior: adjust_base
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,5 +47,13 @@ jobs:
           go-version-file: './go.mod'
       - name: Run tests
         run: make test
-      - name: Codecov
-        uses: codecov/codecov-action@v3
+
+  codecov:
+    name: Upload reports to Codecov
+    needs: envtest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: codecov/codecov-action@v3.1.1
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
           sarif_file: results.sarif
 
   envtest:
-    name: Envtest and coverage report
+    name: Envtest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,6 +47,10 @@ jobs:
           go-version-file: './go.mod'
       - name: Run tests
         run: make test
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: cover.out
 
   codecov:
     name: Upload reports to Codecov
@@ -54,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-report
       - uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
https://issues.redhat.com/browse/STONEBLD-632

Implemented gating pull requests if they decrease overall test coverage by more than 1 %. 
This threshold is subject to change based on feedback, but should cover most false negatives.
Behavior when removing covered lines is subject to change too. [see possible alternatives](https://docs.codecov.com/docs/commit-status#removed_code_behavior)

`codecov/project` check should be made mandatory by repo admins if lowering test coverage should actually block the ability to merge the PR.

Now ignoring `pkg/github` and `pkg/gitlab` because measuring their test coverage  is not desired.

Also split Codecov upload into its own job, so it can be re-ran without re-running the tests. This job should fail in case of an error during upload.

Please see some examples of PRs:
[decreased coverage](https://github.com/tnevrlka/build-service/pull/8)
[increased coverage, but overall decrease due to unexpected changes, still passed](https://github.com/tnevrlka/build-service/pull/11)

See how test coverage can differ even between the same exact code:
[coverage decreased even though it should not have changed, still passed](https://github.com/tnevrlka/build-service/pull/14)
please compare with [exact same code in a different PR, but with a different test coverage](https://github.com/tnevrlka/build-service/pull/15) 