### PR TITLE
STONEBLD-1043, STONEBLD-1046: Renovate update

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -234,6 +234,8 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 				commitMessageExtra: "",
 				commitMessageTopic: "RHTAP references",
 				prFooter: "",
+				prBodyColumns: ["Package", "Change", "Notes"],
+				prBodyDefinitions: { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
 				enabled: true
 			  }
 			]
@@ -246,7 +248,7 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 	if renovatePattern == "" {
 		renovatePattern = DefaultRenovateMatchPattern
 	}
-	return fmt.Sprintf(template, slug, slug, slug, repositoriesData, renovatePattern, renovatePattern)
+	return fmt.Sprintf(template, slug, slug, slug, repositoriesData, renovatePattern, renovatePattern, renovatePattern)
 }
 
 func (r *GitTektonResourcesRenovater) CreateRenovaterJob(ctx context.Context, installations []installationStruct, slug string) error {

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -229,7 +229,11 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 			  {
 				matchPackagePatterns: ["%s"],
 				matchDepPatterns: ["%s"],
-				groupName: "tekton references",
+				groupName: "RHTAP references",
+				branchPrefix: "rhtap/",
+				commitMessageExtra: "",
+				commitMessageTopic: "RHTAP references",
+				prFooter: "",
 				enabled: true
 			  }
 			]


### PR DESCRIPTION
- Rename "tekton references" -> "RHTAP references"
- set branch prefix to rhtap intead of renovate
- set the same PR even when there is only one change in the PR
- When the task version is increased then link to MIGRATION.md from the new version of the task

Test PR https://github.com/Michkov/devfile-sample-go-basic/pull/12 - manually updated config, link does not work