### PR TITLE
Propose to type comment ok-to-test to execute PipelineRun

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -233,7 +233,7 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 				branchPrefix: "rhtap/",
 				commitMessageExtra: "",
 				commitMessageTopic: "RHTAP references",
-				prFooter: "",
+				prFooter: "To execute skipped test pipelines write comment ` + "`/ok-to-test`" + `",
 				prBodyColumns: ["Package", "Change", "Notes"],
 				prBodyDefinitions: { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
 				enabled: true


### PR DESCRIPTION
Currently Pipelines as code requires to type /ok-to-test to execute pipelinerun. Propose to user to type the comment.

Testing PR -> https://github.com/Michkov/devfile-sample-go-basic/pull/13