### PR TITLE
Add labels and annotation with git source information to simple buildpipeline

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Component initial build controller", func() {
 			createSecret(pacSecretKey, pacSecretData)
 
 			github.NewGithubClientByApp = func(appId int64, privateKeyPem []byte, owner string) (*github.GithubClient, error) { return nil, nil }
+			github.NewGithubClientForSimpleBuildByApp = func(appId int64, privateKeyPem []byte) (*github.GithubClient, error) { return nil, nil }
 			github.NewGithubClient = func(accessToken string) *github.GithubClient { return nil }
 			github.IsAppInstalledIntoRepository = func(g *github.GithubClient, owner, repository string) (bool, error) { return true, nil }
 			github.CreatePaCPullRequest = func(c *github.GithubClient, d *github.PaCPullRequestData) (string, error) { return "", nil }
@@ -116,6 +117,7 @@ var _ = Describe("Component initial build controller", func() {
 			github.DeletePaCWebhook = func(g *github.GithubClient, webhookUrl, owner, repository string) error { return nil }
 			gitlab.UndoPaCMergeRequest = func(g *gitlab.GitlabClient, d *gitlab.PaCMergeRequestData) (string, error) { return "", nil }
 			gitlab.DeletePaCWebhook = func(g *gitlab.GitlabClient, projectPath, webhookUrl string) error { return nil }
+			github.GetBranchSHA = func(g *github.GithubClient, owner, repository, branchName string) (string, error) { return "hash", nil }
 
 			createComponentForPaCBuild(getSampleComponentData(resourceKey))
 		})
@@ -1094,16 +1096,68 @@ var _ = Describe("Component initial build controller", func() {
 	Context("Test initial build", func() {
 
 		_ = BeforeEach(func() {
+			github.NewGithubClientForSimpleBuildByApp = func(appId int64, privateKeyPem []byte) (*github.GithubClient, error) { return nil, nil }
+			github.GetBranchSHA = func(g *github.GithubClient, owner, repository, branchName string) (string, error) { return "hash", nil }
+
+			pacSecretData := map[string]string{
+				"github-application-id": "12345",
+				"github-private-key":    githubAppPrivateKey,
+			}
+			createSecret(pacSecretKey, pacSecretData)
+
 			createComponent(resourceKey)
 		})
 
 		_ = AfterEach(func() {
+			deleteSecret(pacSecretKey)
+
 			deleteComponentPipelineRuns(resourceKey)
 			deleteComponent(resourceKey)
 		})
 
 		It("should submit initial build", func() {
+			gitSourceSHA := "d1a9e858489d1515621398fb02942da068f1c956"
+
+			isGetBranchShaInvoked := false
+			github.GetBranchSHA = func(g *github.GithubClient, owner, repository, branchName string) (string, error) {
+				isGetBranchShaInvoked = true
+				Expect(owner).To(Equal("devfile-samples"))
+				Expect(repository).To(Equal("devfile-sample-java-springboot-basic"))
+				return gitSourceSHA, nil
+			}
+
 			setComponentDevfileModel(resourceKey)
+
+			Eventually(func() bool {
+				return isGetBranchShaInvoked
+			}, timeout, interval).Should(BeTrue())
+
+			waitOneInitialPipelineRunCreated(resourceKey)
+			ensureComponentInitialBuildAnnotationState(resourceKey, true)
+
+			// Check pipeline run labels and annotations
+			pipelineRun := listComponentPipelineRuns(resourceKey)[0]
+			Expect(pipelineRun.Labels[pacShaLabelName]).To(Equal(gitSourceSHA))
+			Expect(pipelineRun.Annotations[pacShaUrlAnnotationName]).To(
+				Equal("https://github.com/devfile-samples/devfile-sample-java-springboot-basic/commit/" + gitSourceSHA))
+			Expect(pipelineRun.Annotations[pacRepoUrlAnnotationName]).To(Equal(SampleRepoLink))
+			Expect(pipelineRun.Annotations[gitCommitShaAnnotationName]).To(Equal(gitSourceSHA))
+			Expect(pipelineRun.Annotations[gitRepoAnnotationName]).To(
+				Equal("https://github.com/devfile-samples/devfile-sample-java-springboot-basic?rev=" + gitSourceSHA))
+		})
+
+		It("should submit initial build if retrieving of git commit SHA failed", func() {
+			isGetBranchShaInvoked := false
+			github.GetBranchSHA = func(g *github.GithubClient, owner, repository, branchName string) (string, error) {
+				isGetBranchShaInvoked = true
+				return "", fmt.Errorf("failed to get git commit SHA")
+			}
+
+			setComponentDevfileModel(resourceKey)
+
+			Eventually(func() bool {
+				return isGetBranchShaInvoked
+			}, timeout, interval).Should(BeTrue())
 
 			waitOneInitialPipelineRunCreated(resourceKey)
 			ensureComponentInitialBuildAnnotationState(resourceKey, true)

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -45,7 +45,8 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 			Name:      "my-component",
 			Namespace: "my-namespace",
 			Annotations: map[string]string{
-				"skip-initial-checks": "true",
+				"skip-initial-checks":            "true",
+				gitops.GitProviderAnnotationName: "github",
 			},
 		},
 		Spec: appstudiov1alpha1.ComponentSpec{
@@ -72,8 +73,9 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 		{Name: "revision", Value: tektonapi.ArrayOrString{Type: "string", StringVal: "2378a064bf6b66a8ffc650ad88d404cca24ade29"}},
 		{Name: "rebuild", Value: tektonapi.ArrayOrString{Type: "string", StringVal: "true"}},
 	}
+	commitSHA := "26239c94569cea79b32bce32f12c8abd8bbd0fd7"
 
-	pipelineRun, err := generateInitialPipelineRunForComponent(component, pipelineRef, additionalParams)
+	pipelineRun, err := generateInitialPipelineRunForComponent(component, pipelineRef, additionalParams, commitSHA)
 	if err != nil {
 		t.Error("generateInitialPipelineRunForComponent(): Failed to genertate pipeline run")
 	}
@@ -94,6 +96,9 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 	if pipelineRun.Labels["pipelines.appstudio.openshift.io/type"] != "build" {
 		t.Error("generateInitialPipelineRunForComponent(): wrong pipelines.appstudio.openshift.io/type label value")
 	}
+	if pipelineRun.Labels[pacShaLabelName] != commitSHA {
+		t.Errorf("generateInitialPipelineRunForComponent(): wrong %s label value", pacShaLabelName)
+	}
 
 	if pipelineRun.Annotations["build.appstudio.redhat.com/target_branch"] != "custom-branch" {
 		t.Error("generateInitialPipelineRunForComponent(): wrong build.appstudio.redhat.com/target_branch annotation value")
@@ -103,6 +108,18 @@ func TestGenerateInitialPipelineRunForComponent(t *testing.T) {
 	}
 	if pipelineRun.Annotations["build.appstudio.redhat.com/bundle"] != "pipeline-bundle" {
 		t.Error("generateInitialPipelineRunForComponent(): wrong build.appstudio.redhat.com/bundle annotation value")
+	}
+	if pipelineRun.Annotations[pacShaUrlAnnotationName] != "https://githost.com/user/repo/commit/"+commitSHA {
+		t.Errorf("generateInitialPipelineRunForComponent(): wrong %s annotation value", pacShaUrlAnnotationName)
+	}
+	if pipelineRun.Annotations[pacRepoUrlAnnotationName] != strings.TrimSuffix(component.Spec.Source.GitSource.URL, ".git") {
+		t.Errorf("generateInitialPipelineRunForComponent(): wrong %s annotation value", pacRepoUrlAnnotationName)
+	}
+	if pipelineRun.Annotations[gitCommitShaAnnotationName] != commitSHA {
+		t.Errorf("generateInitialPipelineRunForComponent(): wrong %s annotation value", gitCommitShaAnnotationName)
+	}
+	if pipelineRun.Annotations[gitRepoAnnotationName] != "https://githost.com/user/repo?rev="+commitSHA {
+		t.Errorf("generateInitialPipelineRunForComponent(): wrong %s annotation value", gitRepoAnnotationName)
 	}
 
 	if pipelineRun.Spec.PipelineRef.Name != "pipeline-name" {

--- a/pkg/github/github_client.go
+++ b/pkg/github/github_client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -32,8 +33,9 @@ import (
 )
 
 // Allow mocking for tests
-var NewGithubClientByApp func(appId int64, privateKeyPem []byte, owner string) (*GithubClient, error) = newGithubClientByApp
 var NewGithubClient func(accessToken string) *GithubClient = newGithubClient
+var NewGithubClientByApp func(appId int64, privateKeyPem []byte, owner string) (*GithubClient, error) = newGithubClientByApp
+var NewGithubClientForSimpleBuildByApp func(appId int64, privateKeyPem []byte) (*GithubClient, error) = newGithubClientForSimpleBuildByApp
 var GetInstallations func(appId int64, privateKeyPem []byte) ([]ApplicationInstallation, string, error) = getInstallations
 
 type GithubClient struct {
@@ -103,6 +105,50 @@ func newGithubClientByApp(appId int64, privateKeyPem []byte, owner string) (*Git
 	}
 	// The user has the application installed,
 	// but it doesn't guarantee that the application is installed into all user's repositories.
+
+	token, _, err := client.Apps.CreateInstallationToken(
+		context.Background(),
+		installId,
+		&github.InstallationTokenOptions{})
+	if err != nil {
+		// TODO analyze the error
+		return nil, err
+	}
+
+	return NewGithubClient(token.GetToken()), nil
+}
+
+// newGithubClientForSimpleBuildByApp creates GitHub client based on an instalation token.
+// The installation token is generated based on a randomly picked app installation.
+// This tricky approach is required for simple builds to make requests to GitHub API. Otherwise, rate limit will be hit.
+func newGithubClientForSimpleBuildByApp(appId int64, privateKeyPem []byte) (*GithubClient, error) {
+	itr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appId, privateKeyPem)
+	if err != nil {
+		// Inability to create transport based on a private key indicates that the key is bad formatted
+		return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppMalformedPrivateKey, err)
+	}
+	client := github.NewClient(&http.Client{Transport: itr})
+
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	installations, resp, err := client.Apps.ListInstallations(context.Background(), &opt.ListOptions)
+	if err != nil {
+		if resp != nil && resp.Response != nil && resp.Response.StatusCode != 0 {
+			switch resp.StatusCode {
+			case 401:
+				return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppPrivateKeyNotMatched, err)
+			case 404:
+				return nil, boerrors.NewBuildOpError(boerrors.EGitHubAppDoesNotExist, err)
+			}
+		}
+		return nil, boerrors.NewBuildOpError(boerrors.ETransientError, err)
+	}
+
+	if len(installations) < 1 {
+		return nil, fmt.Errorf("GitHub app is not installed in any repository")
+	}
+	installId := installations[rand.Intn(len(installations))].GetID()
 
 	token, _, err := client.Apps.CreateInstallationToken(
 		context.Background(),

--- a/pkg/github/github_helper.go
+++ b/pkg/github/github_helper.go
@@ -34,6 +34,7 @@ var DeletePaCWebhook func(g *GithubClient, webhookUrl, owner, repository string)
 var IsAppInstalledIntoRepository func(g *GithubClient, owner, repository string) (bool, error) = isAppInstalledIntoRepository
 var GetDefaultBranch func(*GithubClient, string, string) (string, error) = getDefaultBranch
 var FindUnmergedOnboardingMergeRequest func(*GithubClient, string, string, string, string, string) (*github.PullRequest, error) = findUnmergedOnboardingMergeRequest
+var GetBranchSHA func(*GithubClient, string, string, string) (string, error) = getBranchSHA
 var DeleteBranch func(*GithubClient, string, string, string) error = deleteBranch
 
 const (
@@ -306,6 +307,19 @@ func RefineGitHostingServiceError(response *http.Response, originErr error) erro
 
 func getDefaultBranch(client *GithubClient, owner string, repository string) (string, error) {
 	return client.getDefaultBranch(owner, repository)
+}
+
+// getBranchSHA returns SHA of the top commit in the given branch
+func getBranchSHA(client *GithubClient, owner, repository, branchName string) (string, error) {
+	ref, err := client.getReference(owner, repository, branchName)
+	if err != nil {
+		return "", err
+	}
+	if ref.Object == nil {
+		return "", fmt.Errorf("unexpected response")
+	}
+	sha := *ref.Object.SHA
+	return sha, nil
 }
 
 // findUnmergedOnboardingMergeRequest finds out the unmerged merge request that is opened during the component onboarding

--- a/pkg/gitlab/gitlab_client.go
+++ b/pkg/gitlab/gitlab_client.go
@@ -41,6 +41,17 @@ func newGitlabClient(accessToken string) (*GitlabClient, error) {
 	return glc, nil
 }
 
+func (c *GitlabClient) getBranch(projectPath, branchName string) (*gitlab.Branch, error) {
+	branch, resp, err := c.client.Branches.GetBranch(projectPath, branchName)
+	if err != nil {
+		if resp.StatusCode == 404 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return branch, nil
+}
+
 func (c *GitlabClient) branchExist(projectPath, branchName string) (bool, error) {
 	_, resp, err := c.client.Branches.GetBranch(projectPath, branchName)
 	if err != nil {

--- a/pkg/gitlab/gitlab_helper.go
+++ b/pkg/gitlab/gitlab_helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/redhat-appstudio/build-service/pkg/boerrors"
@@ -222,6 +223,19 @@ func RefineGitHostingServiceError(response *http.Response, originErr error) erro
 
 func getDefaultBranch(client *GitlabClient, projectPath string) (string, error) {
 	return client.getDefaultBranch(projectPath)
+}
+
+// GetBranchSHA returns SHA of the top commit in the given branch
+func GetBranchSHA(client *GitlabClient, projectPath, branchName string) (string, error) {
+	branch, err := client.getBranch(projectPath, branchName)
+	if err != nil {
+		return "", err
+	}
+	if branch.Commit == nil {
+		return "", fmt.Errorf("unexpected response")
+	}
+	sha := branch.Commit.ID
+	return sha, nil
 }
 
 // findUnmergedOnboardingMergeRequest finds out the unmerged merge request that is opened during the component onboarding


### PR DESCRIPTION
To correctly display information about simple build pipeline, UI uses some labels and annotations that are created by Tekton on each pipeline run. Make Build-Service set the same labels and annotations for simple builds.

Example of simple build pipeline run:
```yaml
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: go-component-sample-
  annotations:
    build.appstudio.openshift.io/repo: >-
      https://github.com/mmorhun-org/devfile-stack-go?rev=62d1b881e6f8c8e730d33e03aebbd91f9348b652
    build.appstudio.redhat.com/bundle: >-
      quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:b18bbcbd64df838fcf5cc62d9147087a763098bf
    build.appstudio.redhat.com/commit_sha: 62d1b881e6f8c8e730d33e03aebbd91f9348b652
    build.appstudio.redhat.com/pipeline_name: docker-build
    build.appstudio.redhat.com/target_branch: ''
    pipelinesascode.tekton.dev/repo-url: 'https://github.com/mmorhun-org/devfile-stack-go'
    pipelinesascode.tekton.dev/sha-url: >-
      https://github.com/mmorhun-org/devfile-stack-go/commit/62d1b881e6f8c8e730d33e03aebbd91f9348b652
  labels:
    appstudio.openshift.io/application: go-application-sample
    appstudio.openshift.io/component: go-component-sample
    pipelines.appstudio.openshift.io/type: build
    pipelines.openshift.io/runtime: generic
    pipelines.openshift.io/strategy: docker
    pipelines.openshift.io/used-by: build-cloud
    pipelinesascode.tekton.dev/sha: 62d1b881e6f8c8e730d33e03aebbd91f9348b652
    tekton.dev/pipeline: docker-build
```