### PR TITLE
renovater: recreate closed branch

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -233,6 +233,7 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 				prFooter: "To execute skipped test pipelines write comment ` + "`/ok-to-test`" + `",
 				prBodyColumns: ["Package", "Change", "Notes"],
 				prBodyDefinitions: { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
+				recreateClosed: true,
 				enabled: true
 			  }
 			]


### PR DESCRIPTION
Currently when the PR by renovatebot is merged then it's never created again. Enabling 'recrateClosed' fixes the problem.