### PR TITLE
STONEBLD-29: Set slack notifacion on push fail

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,6 +18,8 @@ spec:
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build-service/base/kustomization.yaml
         sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' components/monitoring/grafana/base/build-service/kustomization.yaml
+    - name: slack-webhook-notification-team
+      value: build
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
When push fails then create slack notification on build team channel.