### PR TITLE
chore: update codecov ignore paths

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,7 @@
 comment: off
 
 ignore:
-  - "pkg/github"
-  - "pkg/gitlab"
+  - "pkg/git"
 
 coverage:
   status:


### PR DESCRIPTION
`pkg/github` and `pkg/gitlab` no longer exist since they were refactored into `pkg/git` in https://github.com/redhat-appstudio/build-service/pull/161
This PR updates `ignore` in `.codecov.yml` in order to reflect this change