### PR TITLE
Make TLS certificate verification for PaC webhook configurable

### DIFF
--- a/pkg/git/github/github_client.go
+++ b/pkg/git/github/github_client.go
@@ -257,13 +257,17 @@ func (g *GithubClient) SetupPaCWebhook(repoUrl, webhookUrl, webhookSecret string
 }
 
 func getDefaultWebhookConfig(webhookUrl, webhookSecret string) *github.Hook {
+	insecureSSL := "0"
+	if gp.IsInsecureSSL() {
+		insecureSSL = "1"
+	}
 	return &github.Hook{
 		Events: appStudioPaCWebhookEvents[:],
 		Config: map[string]interface{}{
 			"url":          webhookUrl,
 			"content_type": webhookContentType,
 			"secret":       webhookSecret,
-			"insecure_ssl": "1", // TODO make this field configurable and set defaults to 0
+			"insecure_ssl": insecureSSL,
 		},
 		Active: github.Bool(true),
 	}

--- a/pkg/git/gitlab/gitlab_helper.go
+++ b/pkg/git/gitlab/gitlab_helper.go
@@ -307,7 +307,7 @@ func (g *GitlabClient) deleteWebhook(projectPath string, webhookId int) error {
 }
 
 func getPaCWebhookOpts(webhookTargetUrl, webhookSecret string) *gitlab.AddProjectHookOptions {
-	enableSSLVerification := false
+	enableSSLVerification := !gp.IsInsecureSSL()
 
 	mergeRequestsEvents := true
 	pushEvents := true

--- a/pkg/git/gitprovider/common.go
+++ b/pkg/git/gitprovider/common.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitprovider
+
+import "os"
+
+const (
+	PipelinesAsCodeWebhhokInsecureSslEnvVar = "PAC_WEBHOOK_INSECURE_SSL"
+)
+
+func IsInsecureSSL() bool {
+	if insecureSSLVal := os.Getenv(PipelinesAsCodeWebhhokInsecureSslEnvVar); insecureSSLVal != "" {
+		disableValues := []string{"1", "true", "True"}
+		for _, val := range disableValues {
+			if insecureSSLVal == val {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR allows to configure TLS certificate verification for PaC webhhok.
By default, PaC webhook is created with TLS certificate verification turned on (recommended settings),. To disable it, set `PAC_WEBHOOK_INSECURE_SSL` environment variable for Build Service operator to `1` or `true`.