### PR TITLE
Create missing build-service namespace for a context

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -1802,6 +1802,7 @@ var _ = Describe("Component initial build controller", func() {
 	Context("Test initial build", func() {
 
 		_ = BeforeEach(func() {
+			createNamespace(buildServiceNamespaceName)
 			ResetTestGitProviderClient()
 
 			pacSecretData := map[string]string{


### PR DESCRIPTION
Context "Test initial build" can't run independently without this namespace.