### PR TITLE
RHTAPBUGS-446: add pac types to ensureRequiredAPIGroupsAndResourcesExist

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,6 +228,9 @@ func ensureRequiredAPIGroupsAndResourcesExist(restConfig *rest.Config) {
 			"components",
 			"applications",
 		},
+		"pipelinesascode.tekton.dev": {
+			"repositories",
+		},
 	}
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)


### PR DESCRIPTION
See https://redhat-internal.slack.com/archives/C02FANRBZQD/p1687720654871839 for tl;dr

When pipeline-service goes to openshift-pipelines 1.11, the plan is to go ahead and let the operator install PaC, and stop having the pipeline-service install the upstream version of PaC, since the version installed now by the operator has the minimal set of fixes we need.

As such though, we can hit the timing issue with the PaC CRD creation and controller-runtime setting up watches for the reconcilers, otherwise we hit:

```
2023-06-26T18:44:21.786Z	ERROR	controller/controller.go:329	Reconciler error	{"controller": "component", "controllerGroup": "appstudio.redhat.com", "controllerKind": "Component", "Component": {"name":"rhtap-demo-component-itqm","namespace":"rhtap-demo-dev-woqi-tenant"}, "namespace": "rhtap-demo-dev-woqi-tenant", "name": "rhtap-demo-component-itqm", "reconcileID": "759fdaf0-4c25-48d2-a6ca-6f5020f6763c", "error": "no matches for kind \"Repository\" in version \"pipelinesascode.tekton.dev/v1alpha1\""}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:235
```