### PR TITLE
ci: Add Codecov required check and change Codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,10 @@
 comment: off
 
+codecov:
+  require_ci_to_pass: no
+  notify: 
+    wait_for_ci: no
+
 ignore:
   - "pkg/git"
 
@@ -10,4 +15,6 @@ coverage:
         target: auto
         threshold: 1%
         removed_code_behavior: adjust_base
-
+        if_ci_failed: success
+      required:
+        threshold: 2%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,9 @@ ignore:
 
 coverage:
   status:
+    patch:
+      default:
+        informational: true
     project:
       default:
         target: auto

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,20 +47,7 @@ jobs:
           go-version-file: './go.mod'
       - name: Run tests
         run: make test
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: cover.out
-
-  codecov:
-    name: Upload reports to Codecov
-    needs: envtest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: coverage-report
-      - uses: codecov/codecov-action@v3.1.1
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
Result of [STONEBLD-1439](https://issues.redhat.com/browse/STONEBLD-1439)

Adds a new Codecov project check with threshold 2 % that should be made required by the repository admins.
Should fix issues with the check showing up due to problems with other checks.
Also makes patch check informational and refactors the GitHub Action.