### PR TITLE
feat: add configuration time to PaC build status

### DIFF
--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -433,6 +433,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Update build status annotation
 		buildStatus := readBuildStatus((&component))
+		pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
 		buildStatus.PaC = pacBuildStatus
 		buildStatus.Message = "done"
 		writeBuildStatus(&component, buildStatus)

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -145,6 +145,8 @@ type PaCBuildStatus struct {
 	State string `json:"state,omitempty"`
 	// Contains link to PaC provision / unprovision pull request
 	MergeUrl string `json:"merge-url,omitempty"`
+	// Time of the last PaC configuration
+	ConfigurationTime string `json:"configuration-time,omitempty"`
 
 	ErrorInfo
 }
@@ -410,6 +412,7 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		} else {
 			pacBuildStatus.State = "enabled"
 			pacBuildStatus.MergeUrl = mergeUrl
+			pacBuildStatus.ConfigurationTime = time.Now().Format(time.RFC1123)
 			pacAnnotationValue = PaCProvisionDoneAnnotationValue
 			log.Info("Pipelines as Code provision for the Component finished successfully")
 		}

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -145,7 +145,7 @@ type PaCBuildStatus struct {
 	State string `json:"state,omitempty"`
 	// Contains link to PaC provision / unprovision pull request
 	MergeUrl string `json:"merge-url,omitempty"`
-	// Time of the last PaC configuration
+	// Time of the last successful PaC configuration in RFC1123 format
 	ConfigurationTime string `json:"configuration-time,omitempty"`
 
 	ErrorInfo

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -433,7 +433,9 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Update build status annotation
 		buildStatus := readBuildStatus((&component))
-		pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
+		if pacBuildStatus.ConfigurationTime == "" && buildStatus.PaC != nil && buildStatus.PaC.ConfigurationTime != "" {
+			pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
+		}
 		buildStatus.PaC = pacBuildStatus
 		buildStatus.Message = "done"
 		writeBuildStatus(&component, buildStatus)
@@ -489,6 +491,9 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Update build status annotation
 		buildStatus := readBuildStatus((&component))
+		if pacBuildStatus.ConfigurationTime == "" && buildStatus.PaC != nil && buildStatus.PaC.ConfigurationTime != "" {
+			pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
+		}
 		buildStatus.PaC = pacBuildStatus
 		buildStatus.Message = "done"
 		writeBuildStatus(&component, buildStatus)

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -433,9 +433,6 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Update build status annotation
 		buildStatus := readBuildStatus((&component))
-		if pacBuildStatus.ConfigurationTime == "" && buildStatus.PaC != nil && buildStatus.PaC.ConfigurationTime != "" {
-			pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
-		}
 		buildStatus.PaC = pacBuildStatus
 		buildStatus.Message = "done"
 		writeBuildStatus(&component, buildStatus)
@@ -491,9 +488,6 @@ func (r *ComponentBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Update build status annotation
 		buildStatus := readBuildStatus((&component))
-		if pacBuildStatus.ConfigurationTime == "" && buildStatus.PaC != nil && buildStatus.PaC.ConfigurationTime != "" {
-			pacBuildStatus.ConfigurationTime = buildStatus.PaC.ConfigurationTime
-		}
 		buildStatus.PaC = pacBuildStatus
 		buildStatus.Message = "done"
 		writeBuildStatus(&component, buildStatus)

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -718,6 +718,7 @@ var _ = Describe("Component initial build controller", func() {
 	})
 
 	Context("Test Pipelines as Code build preparation", func() {
+		var latestConfigurationTime string
 
 		_ = BeforeEach(func() {
 			createNamespace(pipelinesAsCodeNamespace)
@@ -781,6 +782,8 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
 			Expect(buildStatus.PaC.MergeUrl).To(Equal(mergeUrl))
+			Expect(buildStatus.PaC.ConfigurationTime).ToNot(BeEmpty())
+			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
 		})
@@ -804,6 +807,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
+			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -826,6 +830,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
+			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -852,6 +857,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
+			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -873,6 +879,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
+			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -907,6 +914,7 @@ var _ = Describe("Component initial build controller", func() {
 				Expect(buildStatus).ToNot(BeNil())
 				Expect(buildStatus.PaC).ToNot(BeNil())
 				Expect(buildStatus.PaC.State).To(Equal("error"))
+				Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 				Expect(buildStatus.PaC.ErrId).To(Equal(appNotInstalledErr.GetErrorId()))
 				Expect(buildStatus.PaC.ErrMessage).To(Equal(appNotInstalledErr.ShortError()))
 				return true
@@ -935,6 +943,8 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
+			Expect(buildStatus.PaC.ConfigurationTime).ToNot(Equal(latestConfigurationTime))
+			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.MergeUrl).To(Equal(mergeUrl))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
@@ -1042,6 +1052,8 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
+			Expect(buildStatus.PaC.ConfigurationTime).ToNot(Equal(latestConfigurationTime))
+			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.MergeUrl).To(Equal("configure-merge-url"))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
@@ -1093,6 +1105,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("disabled"))
+			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.MergeUrl).To(Equal("unconfigure-merge-url"))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -718,8 +718,6 @@ var _ = Describe("Component initial build controller", func() {
 	})
 
 	Context("Test Pipelines as Code build preparation", func() {
-		var latestConfigurationTime string
-
 		_ = BeforeEach(func() {
 			createNamespace(pipelinesAsCodeNamespace)
 			createRoute(pacRouteKey, "pac-host")
@@ -783,7 +781,6 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
 			Expect(buildStatus.PaC.MergeUrl).To(Equal(mergeUrl))
 			Expect(buildStatus.PaC.ConfigurationTime).ToNot(BeEmpty())
-			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
 		})
@@ -807,7 +804,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
-			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
+			Expect(buildStatus.PaC.ConfigurationTime).To(BeEmpty())
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -830,7 +827,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
-			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
+			Expect(buildStatus.PaC.ConfigurationTime).To(BeEmpty())
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -857,7 +854,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
-			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
+			Expect(buildStatus.PaC.ConfigurationTime).To(BeEmpty())
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -879,7 +876,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("error"))
-			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
+			Expect(buildStatus.PaC.ConfigurationTime).To(BeEmpty())
 			Expect(buildStatus.PaC.ErrId).To(Equal(expectedErr.GetErrorId()))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(expectedErr.ShortError()))
 		})
@@ -914,7 +911,7 @@ var _ = Describe("Component initial build controller", func() {
 				Expect(buildStatus).ToNot(BeNil())
 				Expect(buildStatus.PaC).ToNot(BeNil())
 				Expect(buildStatus.PaC.State).To(Equal("error"))
-				Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
+				Expect(buildStatus.PaC.ConfigurationTime).To(BeEmpty())
 				Expect(buildStatus.PaC.ErrId).To(Equal(appNotInstalledErr.GetErrorId()))
 				Expect(buildStatus.PaC.ErrMessage).To(Equal(appNotInstalledErr.ShortError()))
 				return true
@@ -943,8 +940,7 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
-			Expect(buildStatus.PaC.ConfigurationTime).ToNot(Equal(latestConfigurationTime))
-			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
+			Expect(buildStatus.PaC.ConfigurationTime).ToNot(BeEmpty())
 			Expect(buildStatus.PaC.MergeUrl).To(Equal(mergeUrl))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
@@ -1052,8 +1048,8 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
-			Expect(buildStatus.PaC.ConfigurationTime).ToNot(Equal(latestConfigurationTime))
-			latestConfigurationTime = buildStatus.PaC.ConfigurationTime
+			Expect(buildStatus.PaC.ConfigurationTime).ToNot(BeEmpty())
+			latestConfigurationTime := buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.MergeUrl).To(Equal("configure-merge-url"))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))

--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -1049,7 +1049,6 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("enabled"))
 			Expect(buildStatus.PaC.ConfigurationTime).ToNot(BeEmpty())
-			latestConfigurationTime := buildStatus.PaC.ConfigurationTime
 			Expect(buildStatus.PaC.MergeUrl).To(Equal("configure-merge-url"))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))
@@ -1101,7 +1100,6 @@ var _ = Describe("Component initial build controller", func() {
 			Expect(buildStatus).ToNot(BeNil())
 			Expect(buildStatus.PaC).ToNot(BeNil())
 			Expect(buildStatus.PaC.State).To(Equal("disabled"))
-			Expect(buildStatus.PaC.ConfigurationTime).To(Equal(latestConfigurationTime))
 			Expect(buildStatus.PaC.MergeUrl).To(Equal("unconfigure-merge-url"))
 			Expect(buildStatus.PaC.ErrId).To(Equal(0))
 			Expect(buildStatus.PaC.ErrMessage).To(Equal(""))

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -47,7 +47,7 @@ func TestReadBuildStatus(t *testing.T) {
 	}{
 		{
 			name:                       "should be able to read build status with all fields",
-			buildStatusAnnotationValue: "{\"simple\":{\"build-start-time\":\"time\",\"error-id\":1,\"error-message\":\"simple-build-error\"},\"pac\":{\"state\":\"enabled\",\"error-id\":5,\"error-message\":\"pac-error\"},\"message\":\"done\"}",
+			buildStatusAnnotationValue: "{\"simple\":{\"build-start-time\":\"time\",\"error-id\":1,\"error-message\":\"simple-build-error\"},\"pac\":{\"state\":\"enabled\",\"configuration-time\":\"time\",\"error-id\":5,\"error-message\":\"pac-error\"},\"message\":\"done\"}",
 			want: &BuildStatus{
 				Simple: &SimpleBuildStatus{
 					BuildStartTime: "time",
@@ -57,7 +57,8 @@ func TestReadBuildStatus(t *testing.T) {
 					},
 				},
 				PaC: &PaCBuildStatus{
-					State: "enabled",
+					State:             "enabled",
+					ConfigurationTime: "time",
 					ErrorInfo: ErrorInfo{
 						ErrId:      5,
 						ErrMessage: "pac-error",
@@ -126,10 +127,11 @@ func TestWriteBuildStatus(t *testing.T) {
 						ErrId:      5,
 						ErrMessage: "pac-error",
 					},
+					ConfigurationTime: "time",
 				},
 				Message: "done",
 			},
-			want: "{\"simple\":{\"build-start-time\":\"time\",\"error-id\":1,\"error-message\":\"simple-build-error\"},\"pac\":{\"state\":\"enabled\",\"error-id\":5,\"error-message\":\"pac-error\"},\"message\":\"done\"}",
+			want: "{\"simple\":{\"build-start-time\":\"time\",\"error-id\":1,\"error-message\":\"simple-build-error\"},\"pac\":{\"state\":\"enabled\",\"configuration-time\":\"time\",\"error-id\":5,\"error-message\":\"pac-error\"},\"message\":\"done\"}",
 		},
 		{
 			name: "should be able to write build status when annotations is nil",
@@ -165,10 +167,11 @@ func TestWriteBuildStatus(t *testing.T) {
 						ErrId:      10,
 						ErrMessage: "error-ion-pac",
 					},
+					ConfigurationTime: "time",
 				},
 				Message: "done",
 			},
-			want: "{\"pac\":{\"state\":\"error\",\"error-id\":10,\"error-message\":\"error-ion-pac\"},\"message\":\"done\"}",
+			want: "{\"pac\":{\"state\":\"error\",\"configuration-time\":\"time\",\"error-id\":10,\"error-message\":\"error-ion-pac\"},\"message\":\"done\"}",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
[STONEBLD-1522](https://issues.redhat.com/browse/STONEBLD-1522)
Adds `ConfigurationTime` attribute to `BuildStatus.PaC` which stores the time of last successful PaC configuration in RFC1123 format
Updated relevant tests