### PR TITLE
test: add timeouts for flakey tests

### DIFF
--- a/controllers/git_tekton_resources_renovater_test.go
+++ b/controllers/git_tekton_resources_renovater_test.go
@@ -63,8 +63,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 			}
 			componentNamespacedName := createComponentForPaCBuild(getComponentData(componentConfig{gitURL: "https://github/test/repo3"}))
 			createBuildPipelineRunSelector(defaultSelectorKey)
-			time.Sleep(time.Second)
-			Expect(listJobs(buildServiceNamespaceName)).Should(BeEmpty())
+			Eventually(listJobs).WithArguments(buildServiceNamespaceName).WithTimeout(10 * time.Second).Should(BeEmpty())
 			deleteComponent(componentNamespacedName)
 		})
 		It("It should trigger job", func() {
@@ -78,8 +77,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 			}
 			componentNamespacedName := createComponentForPaCBuild(getComponentData(componentConfig{gitURL: "https://github/test/repo1"}))
 			createBuildPipelineRunSelector(defaultSelectorKey)
-			time.Sleep(time.Second)
-			Expect(listJobs(buildServiceNamespaceName)).Should(HaveLen(1))
+			Eventually(listJobs).WithArguments(buildServiceNamespaceName).WithTimeout(10 * time.Second).Should(HaveLen(1))
 			deleteComponent(componentNamespacedName)
 		})
 		It("It should trigger 2 jobs", func() {
@@ -123,8 +121,7 @@ var _ = Describe("Git tekton resources renovater", func() {
 			// Set 2 installations per job
 			os.Setenv(InstallationsPerJobEnvName, "2")
 			createBuildPipelineRunSelector(defaultSelectorKey)
-			time.Sleep(time.Second)
-			Expect(listJobs(buildServiceNamespaceName)).Should(HaveLen(2))
+			Eventually(listJobs).WithArguments(buildServiceNamespaceName).WithTimeout(10 * time.Second).Should(HaveLen(2))
 			deleteComponent(componentNamespacedName1)
 			deleteComponent(componentNamespacedName2)
 			deleteComponent(componentNamespacedName3)


### PR DESCRIPTION
`git_tekton_resources_test` seemed to be flakey as evidenced by running GitHub checks on `build-service` by commiting and pushing empty commits https://github.com/tnevrlka/build-service/pull/17. There seemed to be no problem when testing locally.
This PR adds 10 second timeouts to the affected tests