### PR TITLE
Improve permanent error message logging

### DIFF
--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -46,7 +46,7 @@ func NewBuildOpError(id BOErrorId, err error) *BuildOpError {
 
 func (r BuildOpError) Error() string {
 	if r.err == nil {
-		return ""
+		return r.ShortError()
 	}
 	if r.ExtraInfo == "" {
 		return r.err.Error()
@@ -63,7 +63,10 @@ func (r BuildOpError) GetErrorId() int {
 // standard error message for transient errors.
 func (r BuildOpError) ShortError() string {
 	if r.id == ETransientError {
-		return r.Error()
+		if r.err != nil {
+			return r.err.Error()
+		}
+		return "transient error"
 	}
 	return fmt.Sprintf("%d: %s", r.id, boErrorMessages[r.id])
 }

--- a/pkg/boerrors/perror_test.go
+++ b/pkg/boerrors/perror_test.go
@@ -71,13 +71,13 @@ func TestNestedErrorMessage(t *testing.T) {
 			expectedNestedErrorMessage: "invalid credentials",
 		},
 		{
-			name:                       "should return empty string if nested error is nil",
+			name:                       "should return persistent error id and short error description if nested error is nil",
 			nestedError:                nil,
 			extraInfo:                  "",
-			expectedNestedErrorMessage: "",
+			expectedNestedErrorMessage: "1: unknown error",
 		},
 		{
-			name:                       "should include extra information when there is",
+			name:                       "should include extra information when it's defined",
 			nestedError:                fmt.Errorf("404 no resource []"),
 			extraInfo:                  "permission denied",
 			expectedNestedErrorMessage: "404 no resource [] permission denied",


### PR DESCRIPTION
This PR handles case, when permanent error doesn't have error message in logs. This could happen if permanent error is not caused by any other error, but we just discover condition when we cannot proceed further. In such cases, just return permanent error short description as the error message.