### PR TITLE
Increase test coverage in git_tekton_resources_renovater.go

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -114,11 +114,13 @@ func (r *GitTektonResourcesRenovater) Reconcile(ctx context.Context, req ctrl.Re
 	pacSecret := corev1.Secret{}
 	globalPaCSecretKey := types.NamespacedName{Namespace: buildServiceNamespaceName, Name: gitopsprepare.PipelinesAsCodeSecretName}
 	if err := r.Client.Get(ctx, globalPaCSecretKey, &pacSecret); err != nil {
-		if !errors.IsNotFound(err) {
-			r.EventRecorder.Event(&pacSecret, "Warning", "ErrorReadingPaCSecret", err.Error())
+		r.EventRecorder.Event(&pacSecret, "Warning", "ErrorReadingPaCSecret", err.Error())
+		if errors.IsNotFound(err) {
+			log.Error(err, "not found Pipelines as Code secret in %s namespace: %w", globalPaCSecretKey.Namespace, err, l.Action, l.ActionView)
+		} else {
 			log.Error(err, "failed to get Pipelines as Code secret in %s namespace: %w", globalPaCSecretKey.Namespace, err, l.Action, l.ActionView)
-			return ctrl.Result{}, nil
 		}
+		return ctrl.Result{}, nil
 	}
 	isApp := gitops.IsPaCApplicationConfigured("github", pacSecret.Data)
 	if !isApp {

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -573,6 +573,14 @@ func deleteBuildPipelineRunSelector(selectorKey types.NamespacedName) {
 	}
 }
 
+func listEvents(namespace string) []corev1.Event {
+	events := &corev1.EventList{}
+
+	err := k8sClient.List(ctx, events, client.InNamespace(namespace))
+	Expect(err).ToNot(HaveOccurred())
+	return events.Items
+}
+
 func listJobs(namespace string) []batch.Job {
 	jobs := &batch.JobList{}
 


### PR DESCRIPTION
When checking PACsecret existence, don't filter out NotFound error, as it would fail eventually anyway.

Test for non-existing PACsecret has to be the last, so other test don't conflict with it and won't create secret for it.

[STONEBLD-1590](https://issues.redhat.com//browse/STONEBLD-1590)