### PR TITLE
Fix kube-linter issues for kube-rbac-proxy container

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,4 +31,6 @@ spec:
             memory: 128Mi
           requests:
             cpu: 5m
-            memory: 64Mi     
+            memory: 64Mi
+        securityContext:
+          readOnlyRootFilesystem: true


### PR DESCRIPTION
Set readOnlyRootFilesystem to true.

STONEBLD-1640