### PR TITLE
Reuse existing PaC repository CR for multi component git repositories

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,7 @@ rules:
   - repositories
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/component_build_controller.go
+++ b/controllers/component_build_controller.go
@@ -182,7 +182,7 @@ func (r *ComponentBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=buildpipelineselectors,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=spiaccesstokenbindings,verbs=get;list;watch
 //+kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=create
-//+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch;update
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch

--- a/pkg/boerrors/perror.go
+++ b/pkg/boerrors/perror.go
@@ -87,6 +87,8 @@ const (
 	EPaCSecretInvalid BOErrorId = 51
 	// Pipelines as Code public route to recieve webhook events doesn't exist in expected namespaces.
 	EPaCRouteDoesNotExist BOErrorId = 52
+	// An attempt to create another PaC repository object that references the same git repository.
+	EPaCDuplicateRepository BOErrorId = 53
 
 	// Happens when Component source repository is hosted on unsupported / unknown git provider.
 	// For example: https://my-gitlab.com
@@ -141,9 +143,10 @@ var boErrorMessages = map[BOErrorId]string{
 	ETransientError: "",
 	EUnknownError:   "unknown error",
 
-	EPaCSecretNotFound:    "Pipelines as Code secret does not exist",
-	EPaCSecretInvalid:     "Invalid Pipelines as Code secret",
-	EPaCRouteDoesNotExist: "Pipelines as Code public route does not exist",
+	EPaCSecretNotFound:      "Pipelines as Code secret does not exist",
+	EPaCSecretInvalid:       "Invalid Pipelines as Code secret",
+	EPaCRouteDoesNotExist:   "Pipelines as Code public route does not exist",
+	EPaCDuplicateRepository: "Git repository is already handled by Pipelines as Code",
 
 	EUnknownGitProvider: "unknown git provider of the source repository",
 


### PR DESCRIPTION
This PR changes the way how PaC repository CR is handled. Instead of creation of a new PaC repository per component, Build Service checks if the is existing matching PaC repository and if so, uses it.

Also, error handling logic is added to stop if PaC admission webhook denied PaC repository object creation:
```yaml
build.appstudio.openshift.io/status: '{"pac":{"state":"error","error-id":53,"error-message":"53: Git repository is already handled by Pipelines as Code"},"message":"done"}'
```

Tested using [this](https://github.com/mmorhun/sample-multi-component) sample multi component git repository.