### PR TITLE
Increase test coverage in component_build_controller_pac.go and compo…

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -158,14 +158,14 @@ func (r *ComponentBuildReconciler) UndoPaCProvisionForComponent(ctx context.Cont
 	if err != nil {
 		log.Error(err, "error detecting git provider")
 		// There is no point to continue if git provider is not known.
-		return "", err
+		return "", boerrors.NewBuildOpError(boerrors.EUnknownGitProvider, err)
 	}
 
 	pacSecret := corev1.Secret{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: buildServiceNamespaceName, Name: gitopsprepare.PipelinesAsCodeSecretName}, &pacSecret); err != nil {
 		log.Error(err, "error getting git provider credentials secret", l.Action, l.ActionView)
 		// Cannot continue without accessing git provider credentials.
-		return "", err
+		return "", boerrors.NewBuildOpError(boerrors.EPaCSecretNotFound, err)
 	}
 
 	webhookTargetUrl := ""

--- a/controllers/suite_util_gitprovider_test.go
+++ b/controllers/suite_util_gitprovider_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	testGitProviderClient = &TestGitProviderClient{}
+	testGitProviderClient   = &TestGitProviderClient{}
+	DefaultBrowseRepository = "https://githost.com/user/repo?rev="
 
 	EnsurePaCMergeRequestFunc        func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error)
 	UndoPaCMergeRequestFunc          func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error)
@@ -67,7 +68,7 @@ func ResetTestGitProviderClient() {
 		return "abcd890", nil
 	}
 	GetBrowseRepositoryAtShaLinkFunc = func(repoUrl string, sha string) string {
-		return "https://githost.com/user/repo?rev=" + sha
+		return DefaultBrowseRepository + sha
 	}
 	IsRepositoryPublicFunc = func(repoUrl string) (bool, error) {
 		return true, nil


### PR DESCRIPTION
…nent_build_controller_simple_build.go

Properly handle errors when:
gitprovider can't be detected
pac secret doesn't exist

When UndoPaCProvisionForComponent fails with persistent error set buildStatus.State to error

Added 1 sec sleep in AfterEach after component deletion, so it waits for pruner