### PR TITLE
Add kube-linter check

### DIFF
--- a/.github/.kube-linter-config.yaml
+++ b/.github/.kube-linter-config.yaml
@@ -1,0 +1,7 @@
+checks:
+  # include explicitly adds checks, by name. You can reference any of the built-in checks.
+  # Note that customChecks defined above are included automatically.
+  include: [ ]
+  # exclude explicitly excludes checks, by name. exclude has the highest priority: if a check is
+  # in exclude, then it is not considered, even if it is in include as well.
+  exclude: [ ]

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -1,0 +1,54 @@
+name: Check Kubernetes YAMLs with kube-linter
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'config/default/**.ya?ml'
+      - 'config/crd/**.ya?ml'
+      - 'config/rbac/**.ya?ml'
+      - 'config/manager/**.ya?ml'
+      - 'config/monitoring/prometheus/**.ya?ml'
+
+jobs:
+  kube-linter:
+    name: Kube linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create ../kube-linter/ for deployment yaml files
+        shell: bash
+        run: mkdir -p ../kube-linter/
+
+      - name: Generate Build Service operator deployment configuration
+        shell: bash
+        run: kustomize build config/default/ >  ../kube-linter/build-service.yaml
+
+      - name: Scan yaml files with kube-linter
+        uses: stackrox/kube-linter-action@v1
+        id: kube-linter-action-scan
+        with:
+          # Where to do scanning
+          directory: ../kube-linter/
+          # Where to search for kube-linter config. Removing the setting make using the default config.
+          config: ./.github/.kube-linter-config.yaml
+          # The following two settings make kube-linter produce scan analysis in SARIF format
+          # which would then be made available in GitHub UI via upload-sarif action below.
+          format: sarif
+          output-file: ../kube-linter/kube-linter.sarif
+        # The following line prevents aborting the workflow immediately in case your files fail kube-linter checks.
+        # This allows the following upload-sarif action to still upload the results to your GitHub repo.
+        continue-on-error: true
+
+      - name: Upload SARIF report files to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ../kube-linter/kube-linter.sarif
+
+      # Ensure the workflow eventually fails if files did not pass kube-linter checks.
+      - name: Verify kube-linter-action succeeded
+        shell: bash
+        run: |
+          echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
+          [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]


### PR DESCRIPTION
This PR adds `kube-linter` check that runs only if change to the operator deployment configuration is made.