### PR TITLE
Refactor component_build_controller_test.go

### DIFF
--- a/controllers/suite_util_gitprovider_test.go
+++ b/controllers/suite_util_gitprovider_test.go
@@ -24,6 +24,7 @@ import (
 var (
 	testGitProviderClient   = &TestGitProviderClient{}
 	DefaultBrowseRepository = "https://githost.com/user/repo?rev="
+	UndoPacMergeRequestURL  = "https://githost.com/mr/5678"
 
 	EnsurePaCMergeRequestFunc        func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error)
 	UndoPaCMergeRequestFunc          func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error)
@@ -47,7 +48,7 @@ func ResetTestGitProviderClient() {
 		return "https://githost.com/mr/1234", nil
 	}
 	UndoPaCMergeRequestFunc = func(repoUrl string, data *gp.MergeRequestData) (webUrl string, err error) {
-		return "https://githost.com/mr/5678", nil
+		return UndoPacMergeRequestURL, nil
 	}
 	FindUnmergedPaCMergeRequestFunc = func(repoUrl string, data *gp.MergeRequestData) (*gp.MergeRequest, error) {
 		return nil, nil


### PR DESCRIPTION
Use different componet name for each context

New helper methods for:
creating custom component from privided data, with wait for component
check pac buildstatus with commonly checked keys
check simple buildstatus with commonly checked keys