### PR TITLE
Allow manually trigger PaC builds

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,6 +80,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -113,7 +113,7 @@ func getComponentData(config componentConfig) *appstudiov1alpha1.Component {
 	}
 	gitUrl := config.gitURL
 	if gitUrl == "" {
-		gitUrl = SampleRepoLink
+		gitUrl = SampleRepoLink + "-" + name
 	}
 	gitRevision := config.gitRevision
 	if gitRevision == "" {
@@ -170,6 +170,12 @@ func createComponentAndProcessBuildRequest(componentKey types.NamespacedName, bu
 // This method also sets devfile model, so the component is ready to be processed.
 func createComponentWithBuildRequest(componentKey types.NamespacedName, buildRequest string) {
 	createCustomComponentWithBuildRequest(componentConfig{componentKey: componentKey}, buildRequest)
+}
+
+// createComponentWithBuildRequestAndGitcreate a component with specified build request, and provided gitURL and revision.
+// This method also sets devfile model, so the component is ready to be processed.
+func createComponentWithBuildRequestAndGit(componentKey types.NamespacedName, buildRequest string, gitURL string, gitRevision string) {
+	createCustomComponentWithBuildRequest(componentConfig{componentKey: componentKey, gitURL: gitURL, gitRevision: gitRevision}, buildRequest)
 }
 
 func createCustomComponentWithBuildRequest(config componentConfig, buildRequest string) {
@@ -488,6 +494,14 @@ func ensureSecretNotCreated(resourceKey types.NamespacedName) {
 		err := k8sClient.Get(ctx, resourceKey, secret)
 		return k8sErrors.IsNotFound(err)
 	}, timeout, interval).WithTimeout(ensureTimeout).Should(BeTrue())
+}
+
+func waitSecretGone(resourceKey types.NamespacedName) {
+	secret := &corev1.Secret{}
+	Eventually(func() bool {
+		err := k8sClient.Get(ctx, resourceKey, secret)
+		return k8sErrors.IsNotFound(err)
+	}, timeout, interval).Should(BeTrue())
 }
 
 func createNamespace(name string) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/h2non/gock v1.2.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openshift/api v0.0.0-20221013123534-96eec44e1979
@@ -90,6 +91,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -645,7 +645,10 @@ github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4G
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
+github.com/h2non/gock v1.2.0 h1:K6ol8rfrRkUOefooBC8elXoaNGYkpp7y2qcxGG6BzUE=
+github.com/h2non/gock v1.2.0/go.mod h1:tNhoxHYW2W42cYkYb1WqzdbYIieALC99kpYr7rH/BQk=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -838,6 +841,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=


### PR DESCRIPTION
    When component is provisioned for PaC, we are able to re-trigger push
    pipeline (which wouldn't be otherwise possible) by adding request
    annotation to component:
    build.appstudio.openshift.io/request: trigger-pac-build
    
    It will update incomings in repository, and create secret which is used
    for trigger. And run push pipeline for a component.
    
    STONEBLD-1438
