### PR TITLE
Allow git repository to be referenced from different components without context directory

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -522,12 +522,13 @@ func deleteNamespace(name string) {
 	}
 }
 
-func waitPaCRepositoryCreated(resourceKey types.NamespacedName) {
+func waitPaCRepositoryCreated(resourceKey types.NamespacedName) *pacv1alpha1.Repository {
 	pacRepository := &pacv1alpha1.Repository{}
 	Eventually(func() bool {
 		err := k8sClient.Get(ctx, resourceKey, pacRepository)
 		return err == nil && pacRepository.ResourceVersion != ""
 	}, timeout, interval).Should(BeTrue())
+	return pacRepository
 }
 
 func deletePaCRepository(resourceKey types.NamespacedName) {


### PR DESCRIPTION
This PR removes limitation for monorepo components to have context directory.
Now, the following scenarios are possible:
- Single codebase with different Dockerfile for each component
- Each Component is in a separate branch