### PR TITLE
Use cel expression for build pipeline event filtering

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -567,14 +567,15 @@ var _ = Describe("Component initial build controller", func() {
 
 			isCreatePaCPullRequestInvoked := false
 			EnsurePaCMergeRequestFunc = func(repoUrl string, d *gp.MergeRequestData) (string, error) {
+				defer GinkgoRecover()
 				Expect(d.BaseBranchName).To(Equal(repoDefaultBranch))
 				for _, file := range d.Files {
 					var prYaml tektonapi.PipelineRun
 					if err := yaml.Unmarshal(file.Content, &prYaml); err != nil {
 						return "", err
 					}
-					targetBranches := prYaml.Annotations["pipelinesascode.tekton.dev/on-target-branch"]
-					Expect(targetBranches).To(Equal(fmt.Sprintf("[%s]", repoDefaultBranch)))
+					targetBranch := prYaml.Annotations[pacCelExpressionAnnotationName]
+					Expect(targetBranch).To(ContainSubstring(fmt.Sprintf(`target_branch == "%s"`, repoDefaultBranch)))
 				}
 				isCreatePaCPullRequestInvoked = true
 				return "url", nil

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -31,6 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -510,8 +511,8 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 		t.Error("generatePaCPipelineRunForComponent(): wrong pipelines.appstudio.openshift.io/type label value")
 	}
 
-	if pipelineRun.Annotations["pipelinesascode.tekton.dev/on-target-branch"] != "["+branchName+"]" {
-		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/on-target-branch annotation value")
+	if pipelineRun.Annotations["pipelinesascode.tekton.dev/on-cel-expression"] != `event == "pull_request" && target_branch == "custom-branch"` {
+		t.Errorf("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/on-cel-expression annotation value")
 	}
 	if pipelineRun.Annotations["pipelinesascode.tekton.dev/max-keep-runs"] != "3" {
 		t.Error("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/max-keep-runs annotation value")
@@ -524,9 +525,6 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	}
 	if pipelineRun.Annotations[gitRepoAtShaAnnotationName] != "https://githost.com/user/repo?rev={{revision}}" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong %s annotation value", gitRepoAtShaAnnotationName)
-	}
-	if pipelineRun.Annotations["pipelinesascode.tekton.dev/on-event"] != "[pull_request]" {
-		t.Errorf("generatePaCPipelineRunForComponent(): wrong pipelinesascode.tekton.dev/on-event annotation value")
 	}
 	if pipelineRun.Annotations["build.appstudio.redhat.com/pull_request_number"] != "{{pull_request_number}}" {
 		t.Errorf("generatePaCPipelineRunForComponent(): wrong build.appstudio.redhat.com/pull_request_number annotation value")
@@ -628,6 +626,170 @@ func TestGeneratePaCPipelineRunForComponent_ShouldStopIfTargetBranchIsNotSet(t *
 	if err == nil {
 		t.Errorf("generatePaCPipelineRunForComponent(): expected error")
 	}
+}
+
+func TestGenerateCelExpressionForPipeline(t *testing.T) {
+	componentKey := types.NamespacedName{Namespace: "test-ns", Name: "component-name"}
+	ResetTestGitProviderClient()
+
+	tests := []struct {
+		name              string
+		component         *appstudiov1alpha1.Component
+		targetBranch      string
+		isDockerfileExist func(repoUrl, branch, dockerfilePath string) (bool, error)
+		wantOnPullError   bool
+		wantOnPull        string
+		wantOnPush        string
+	}{
+		{
+			name: "should generate cel expression for component that occupies whole git repository",
+			component: func() *appstudiov1alpha1.Component {
+				component := getSampleComponentData(componentKey)
+				component.Status.Devfile = getMinimalDevfile()
+				return component
+			}(),
+			targetBranch: "my-branch",
+			wantOnPull:   `event == "pull_request" && target_branch == "my-branch"`,
+			wantOnPush:   `event == "push" && target_branch == "my-branch"`,
+		},
+		{
+			name: "should generate cel expression for component with context directory, without dokerfile",
+			component: func() *appstudiov1alpha1.Component {
+				component := getComponentData(componentConfig{componentKey: componentKey, gitSourceContext: "component-dir"})
+				component.Status.Devfile = getMinimalDevfile()
+				return component
+			}(),
+			targetBranch: "my-branch",
+			wantOnPull:   `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() )`,
+			wantOnPush:   `event == "push" && target_branch == "my-branch"`,
+		},
+		{
+			name: "should generate cel expression for component with context directory and its dockerfile in context directory",
+			component: func() *appstudiov1alpha1.Component {
+				component := getComponentData(componentConfig{componentKey: componentKey, gitSourceContext: "component-dir"})
+				component.Status.Devfile = `
+                    schemaVersion: 2.2.0
+                    metadata:
+                        name: devfile-no-dockerfile
+                    components:
+                      - name: outerloop-build
+                        image:
+                            imageName: image:latest
+                            dockerfile:
+                                uri: docker/Dockerfile
+                `
+				return component
+			}(),
+			targetBranch: "my-branch",
+			isDockerfileExist: func(repoUrl, branch, dockerfilePath string) (bool, error) {
+				return true, nil
+			},
+			wantOnPull: `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() )`,
+			wantOnPush: `event == "push" && target_branch == "my-branch"`,
+		},
+		{
+			name: "should generate cel expression for component with context directory and its dockerfile outside context directory",
+			component: func() *appstudiov1alpha1.Component {
+				component := getComponentData(componentConfig{componentKey: componentKey, gitSourceContext: "component-dir"})
+				component.Status.Devfile = `
+                    schemaVersion: 2.2.0
+                    metadata:
+                        name: devfile-no-dockerfile
+                    components:
+                      - name: outerloop-build
+                        image:
+                            imageName: image:latest
+                            dockerfile:
+                                uri: docker-root-dir/Dockerfile
+                `
+				return component
+			}(),
+			targetBranch: "my-branch",
+			isDockerfileExist: func(repoUrl, branch, dockerfilePath string) (bool, error) {
+				return false, nil
+			},
+			wantOnPull: `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() || "/docker-root-dir/Dockerfile".pathChanged() )`,
+			wantOnPush: `event == "push" && target_branch == "my-branch"`,
+		},
+		{
+			name: "should generate cel expression for component with context directory and its dockerfile outside git repository",
+			component: func() *appstudiov1alpha1.Component {
+				component := getComponentData(componentConfig{componentKey: componentKey, gitSourceContext: "component-dir"})
+				component.Status.Devfile = `
+                    schemaVersion: 2.2.0
+                    metadata:
+                        name: devfile-no-dockerfile
+                    components:
+                      - name: outerloop-build
+                        image:
+                            imageName: image:latest
+                            dockerfile:
+                                uri: https://host.com:1234/files/Dockerfile
+                `
+				return component
+			}(),
+			targetBranch: "my-branch",
+			wantOnPull:   `event == "pull_request" && target_branch == "my-branch" && ( "component-dir/***".pathChanged() )`,
+			wantOnPush:   `event == "push" && target_branch == "my-branch"`,
+		},
+		{
+			name: "should fail to generate cel expression for component if isFileExist fails",
+			component: func() *appstudiov1alpha1.Component {
+				component := getComponentData(componentConfig{componentKey: componentKey, gitSourceContext: "component-dir"})
+				component.Status.Devfile = `
+                    schemaVersion: 2.2.0
+                    metadata:
+                        name: devfile-no-dockerfile
+                    components:
+                      - name: outerloop-build
+                        image:
+                            imageName: image:latest
+                            dockerfile:
+                                uri: docker-root-dir/Dockerfile
+                `
+				return component
+			}(),
+			targetBranch: "my-branch",
+			isDockerfileExist: func(repoUrl, branch, dockerfilePath string) (bool, error) {
+				return false, fmt.Errorf("Failed to check file existance")
+			},
+			wantOnPullError: true,
+			wantOnPush:      `event == "push" && target_branch == "my-branch"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.isDockerfileExist != nil {
+				IsFileExistFunc = tt.isDockerfileExist
+			} else {
+				IsFileExistFunc = func(repoUrl, branchName, filePath string) (bool, error) {
+					t.Errorf("IsFileExist should not be invoked")
+					return false, nil
+				}
+			}
+
+			got, err := generateCelExpressionForPipeline(tt.component, testGitProviderClient, tt.targetBranch, true)
+			if err != nil {
+				if !tt.wantOnPullError {
+					t.Errorf("generateCelExpressionForPipeline(on pull): got err: %v", err)
+				}
+			} else {
+				if got != tt.wantOnPull {
+					t.Errorf("generateCelExpressionForPipeline(on pull): got '%s', want '%s'", got, tt.wantOnPull)
+				}
+			}
+
+			got, err = generateCelExpressionForPipeline(tt.component, testGitProviderClient, tt.targetBranch, false)
+			if err != nil {
+				t.Errorf("generateCelExpressionForPipeline(on push): got err: %v", err)
+			}
+			if got != tt.wantOnPush {
+				t.Errorf("generateCelExpressionForPipeline(on push): got '%s', want '%s'", got, tt.wantOnPush)
+			}
+		})
+	}
+	ResetTestGitProviderClient()
 }
 
 func TestGetContainerImageRepository(t *testing.T) {

--- a/controllers/suite_util_gitprovider_test.go
+++ b/controllers/suite_util_gitprovider_test.go
@@ -35,6 +35,7 @@ var (
 	DeleteBranchFunc                 func(repoUrl string, branchName string) (bool, error)
 	GetBranchShaFunc                 func(repoUrl string, branchName string) (string, error)
 	GetBrowseRepositoryAtShaLinkFunc func(repoUrl string, sha string) string
+	IsFileExistFunc                  func(repoUrl, branchName, filePath string) (bool, error)
 	IsRepositoryPublicFunc           func(repoUrl string) (bool, error)
 	GetConfiguredGitAppNameFunc      func() (string, string, error)
 )
@@ -70,6 +71,9 @@ func ResetTestGitProviderClient() {
 	}
 	GetBrowseRepositoryAtShaLinkFunc = func(repoUrl string, sha string) string {
 		return DefaultBrowseRepository + sha
+	}
+	IsFileExistFunc = func(repoUrl, branchName, filePath string) (bool, error) {
+		return true, nil
 	}
 	IsRepositoryPublicFunc = func(repoUrl string) (bool, error) {
 		return true, nil
@@ -109,6 +113,9 @@ func (*TestGitProviderClient) GetBranchSha(repoUrl string, branchName string) (s
 }
 func (*TestGitProviderClient) GetBrowseRepositoryAtShaLink(repoUrl string, sha string) string {
 	return GetBrowseRepositoryAtShaLinkFunc(repoUrl, sha)
+}
+func (*TestGitProviderClient) IsFileExist(repoUrl, branchName, filePath string) (bool, error) {
+	return IsFileExistFunc(repoUrl, branchName, filePath)
 }
 func (*TestGitProviderClient) IsRepositoryPublic(repoUrl string) (bool, error) {
 	return IsRepositoryPublicFunc(repoUrl)

--- a/pkg/git/github/github_client.go
+++ b/pkg/git/github/github_client.go
@@ -19,6 +19,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/go-github/v45/github"
@@ -324,6 +325,27 @@ func (g *GithubClient) GetBranchSha(repoUrl, branchName string) (string, error) 
 	}
 	sha := ref.GetObject().GetSHA()
 	return sha, nil
+}
+
+// IsFileExist check whether given file exists in the given branch of the reposiotry.
+// If branch is empty string, default branch is used.
+func (g *GithubClient) IsFileExist(repoUrl, branchName, filePath string) (bool, error) {
+	owner, repository := getOwnerAndRepoFromUrl(repoUrl)
+
+	if branchName == "" {
+		var err error
+		branchName, err = g.getDefaultBranch(owner, repository)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	directory := filepath.Dir(filePath)
+	files, err := g.filesExistInDirectory(owner, repository, branchName, directory, []gp.RepositoryFile{{FullPath: filePath}})
+	if err != nil {
+		return false, err
+	}
+	return len(files) > 0, nil
 }
 
 // IsRepositoryPublic returns true if the repository could be accessed without authentication

--- a/pkg/git/gitlab/gitlab_client.go
+++ b/pkg/git/gitlab/gitlab_client.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/xanzy/go-gitlab"
@@ -245,6 +246,27 @@ func (g *GitlabClient) GetBranchSha(repoUrl, branchName string) (string, error) 
 	}
 	sha := branch.Commit.ID
 	return sha, nil
+}
+
+// IsFileExist check whether given file exists in the given branch of the reposiotry.
+// If branch is empty string, default branch is used.
+func (g *GitlabClient) IsFileExist(repoUrl, branchName, filePath string) (bool, error) {
+	projectPath := getProjectPathFromRepoUrl(repoUrl)
+
+	if branchName == "" {
+		var err error
+		branchName, err = g.getDefaultBranch(projectPath)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	directory := filepath.Dir(filePath)
+	files, err := g.filesExistInDirectory(projectPath, branchName, directory, []gp.RepositoryFile{{FullPath: filePath}})
+	if err != nil {
+		return false, err
+	}
+	return len(files) > 0, nil
 }
 
 // IsRepositoryPublic returns true if the repository could be accessed without authentication

--- a/pkg/git/gitprovider/gitprovider.go
+++ b/pkg/git/gitprovider/gitprovider.go
@@ -48,6 +48,9 @@ type GitProviderClient interface {
 	// GetBranchSha returns SHA of top commit in the given branch
 	GetBranchSha(repoUrl, branchName string) (string, error)
 
+	// IsFileExist check whether given file exists in the given branch of the reposiotry
+	IsFileExist(repoUrl, branchName, filePath string) (bool, error)
+
 	// IsRepositoryPublic returns true if the repository could be accessed without authentication
 	IsRepositoryPublic(repoUrl string) (bool, error)
 


### PR DESCRIPTION
This PR prevents redundant builds for multi component git repositories. A new build is started only if files related to the Component are changed.