### PR TITLE
don't add in on-cell-expression ./ context dir

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -1089,7 +1089,7 @@ func generateCelExpressionForPipeline(component *appstudiov1alpha1.Component, gi
 	// Set path changed event filtering only for Components that are stored within a directory of the git repository.
 	// Also, we have to rebuild everything on push events, so applying the filter only to pull request pipeline.
 	pathChangedSuffix := ""
-	if onPull && component.Spec.Source.GitSource.Context != "" && component.Spec.Source.GitSource.Context != "/" {
+	if onPull && component.Spec.Source.GitSource.Context != "" && component.Spec.Source.GitSource.Context != "/" && component.Spec.Source.GitSource.Context != "./" && component.Spec.Source.GitSource.Context != "." {
 		contextDir := component.Spec.Source.GitSource.Context
 		if !strings.HasSuffix(contextDir, "/") {
 			contextDir += "/"


### PR DESCRIPTION
resulting in "./***".pathChanged() because that doesn't trigger builds

[RHTAPBUGS-947](https://issues.redhat.com//browse/RHTAPBUGS-947)