### PR TITLE
Disable semantic commit message for renovate

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -240,6 +240,7 @@ func generateConfigJS(slug string, repositories []renovateRepository) string {
 				branchName: "rhtap/references/{{baseBranch}}",
 				commitMessageExtra: "",
 				commitMessageTopic: "RHTAP references",
+				semanticCommits: "enabled",
 				prFooter: "To execute skipped test pipelines write comment ` + "`/ok-to-test`" + `",
 				prBodyColumns: ["Package", "Change", "Notes"],
 				prBodyDefinitions: { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },


### PR DESCRIPTION
This PR disables semantic commit message style fro renovate bot commits.
This is done to prevent renovate updating own PR in a loop when it fails to properly auto-detect whether to use semantic commit messages.