### PR TITLE
Remove unnecessary assert

### DIFF
--- a/controllers/component_build_controller_test.go
+++ b/controllers/component_build_controller_test.go
@@ -1517,7 +1517,6 @@ var _ = Describe("Component initial build controller", func() {
 			createComponentCustom(component)
 			setComponentDevfileModel(resouceSimpleBuildKey)
 			waitOneInitialPipelineRunCreated(resouceSimpleBuildKey)
-			waitComponentAnnotationGone(resouceSimpleBuildKey, BuildRequestAnnotationName)
 			waitDoneMessageOnComponent(resouceSimpleBuildKey)
 			expectSimpleBuildStatus(resouceSimpleBuildKey, 0, "", false)
 		})


### PR DESCRIPTION
The test triggers a simple build without needing the request annotation. If both request and status annotation are not set, the controller treats it as a simple build.