### PR TITLE
fix(rhtapbugs=975): use source_url instead of repo_url for git-url

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -1076,7 +1076,7 @@ func generatePaCPipelineRunForComponent(
 	}
 
 	params := []tektonapi.Param{
-		{Name: "git-url", Value: tektonapi.ParamValue{Type: "string", StringVal: "{{repo_url}}"}},
+		{Name: "git-url", Value: tektonapi.ParamValue{Type: "string", StringVal: "{{source_url}}"}},
 		{Name: "revision", Value: tektonapi.ParamValue{Type: "string", StringVal: "{{revision}}"}},
 		{Name: "output-image", Value: tektonapi.ParamValue{Type: "string", StringVal: proposedImage}},
 	}

--- a/controllers/component_build_controller_unit_test.go
+++ b/controllers/component_build_controller_unit_test.go
@@ -546,7 +546,7 @@ func TestGeneratePaCPipelineRunForComponent(t *testing.T) {
 	for _, param := range pipelineRun.Spec.Params {
 		switch param.Name {
 		case "git-url":
-			if param.Value.StringVal != "{{repo_url}}" {
+			if param.Value.StringVal != "{{source_url}}" {
 				t.Errorf("generatePaCPipelineRunForComponent(): wrong pipeline parameter %s", param.Name)
 			}
 		case "revision":


### PR DESCRIPTION
The repo_url variable in pull request jobs points to the target repo. The git-url parameter of build pipelineRuns is passed to the integration service.  If users attempt to clone this URL with the revision from the 'revision' parameter (which is the revision of the source URL) an error will occur.  Tekton also has a 'source_url' variable that points to the source repo in pull request jobs, which fixes the problem.  In push jobs 'source_repo' defaults to the same value as 'repo_url'.  Therefore defaulting to 'source_repo' should not cause any other bugs'

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable