### PR TITLE
fix: Update dev/stage after push

### DIFF
--- a/.tekton/build-service-push.yaml
+++ b/.tekton/build-service-push.yaml
@@ -16,8 +16,8 @@ spec:
       value: 'quay.io/redhat-appstudio/build-service:{{revision}}'
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build-service/base/kustomization.yaml
-        sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' components/monitoring/grafana/base/dashboards/build-service/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build-service/development/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/build-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build-service/staging/base/kustomization.yaml
     - name: slack-webhook-notification-team
       value: build
   pipelineRef:


### PR DESCRIPTION
We will be only updating dev&stage overlays during push pipelinerun. graphana update will be moved to another pipeline when we will be updating production overlay.
This PR is part of the story: https://issues.redhat.com/browse/STONEBLD-1924

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable