### PR TITLE
RHTAP-1134: Support custom Gitlab instances

### DIFF
--- a/pkg/git/gitlab/gitlab_client.go
+++ b/pkg/git/gitlab/gitlab_client.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Allow mocking for tests
-var NewGitlabClient func(accessToken string) (*GitlabClient, error) = newGitlabClient
+var NewGitlabClient func(accessToken, baseUrl string) (*GitlabClient, error) = newGitlabClient
 
 var _ gp.GitProviderClient = (*GitlabClient)(nil)
 
@@ -330,9 +330,9 @@ func (g *GitlabClient) GetConfiguredGitAppName() (string, string, error) {
 	return "", "", fmt.Errorf("GitLab does not support applications")
 }
 
-func newGitlabClient(accessToken string) (*GitlabClient, error) {
+func newGitlabClient(accessToken, baseUrl string) (*GitlabClient, error) {
 	glc := &GitlabClient{}
-	c, err := gitlab.NewClient(accessToken)
+	c, err := gitlab.NewClient(accessToken, gitlab.WithBaseURL(baseUrl))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/gitlab/gitlab_helper_debug_test.go
+++ b/pkg/git/gitlab/gitlab_helper_debug_test.go
@@ -38,7 +38,12 @@ func TestEnsurePaCMergeRequest(t *testing.T) {
 		return
 	}
 
-	glclient, err := NewGitlabClient(accessToken)
+	baseUrl, err := GetBaseUrl(repoUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	glclient, err := NewGitlabClient(accessToken, baseUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +80,12 @@ func TestUndoPaCMergeRequest(t *testing.T) {
 		return
 	}
 
-	glclient, err := NewGitlabClient(accessToken)
+	baseUrl, err := GetBaseUrl(repoUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	glclient, err := NewGitlabClient(accessToken, baseUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +122,12 @@ func TestSetupPaCWebhook(t *testing.T) {
 	targetWebhookUrl := "https://pac.route.my-cluster.net"
 	webhookSecretString := "d01b38971dad59514298d763f288392c08221043"
 
-	glclient, err := NewGitlabClient(accessToken)
+	baseUrl, err := GetBaseUrl(repoUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	glclient, err := NewGitlabClient(accessToken, baseUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +145,12 @@ func TestDeletePaCWebhook(t *testing.T) {
 
 	targetWebhookUrl := "https://pac.route.my-cluster.net"
 
-	glclient, err := NewGitlabClient(accessToken)
+	baseUrl, err := GetBaseUrl(repoUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	glclient, err := NewGitlabClient(accessToken, baseUrl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +166,12 @@ func TestIsRepositoryPublic(t *testing.T) {
 		return
 	}
 
-	glclient, err := NewGitlabClient(accessToken)
+	baseUrl, err := GetBaseUrl(repoUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	glclient, err := NewGitlabClient(accessToken, baseUrl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/git/gitlab/gitlab_helper_test.go
+++ b/pkg/git/gitlab/gitlab_helper_test.go
@@ -56,3 +56,118 @@ func TestGetProjectPathFromRepoUrl(t *testing.T) {
 		}
 	}
 }
+
+func TestGetHostFromRepoUrl(t *testing.T) {
+	var params = []struct {
+		in  string
+		out string
+		err error
+	}{
+		{
+			"https://gitlab.host.com/rhtap/tenants-config.git",
+			"https://gitlab.host.com/",
+			nil,
+		},
+		{
+			"https://gitlab.com/projectname",
+			"https://gitlab.com/",
+			nil,
+		},
+		{
+			"http!!://abc",
+			"",
+			FailedToParseUrlError{},
+		},
+	}
+
+	for _, tt := range params {
+		t.Run(tt.in, func(t *testing.T) {
+			actual, err := GetBaseUrl(tt.in)
+			if err != nil && tt.err == nil {
+				t.Fatalf("Expected call to succeed, found error %s", err.Error())
+			}
+			if err == nil && tt.err != nil {
+				t.Fatalf("Expected call to end with an error, but it succeed")
+			}
+			if actual != tt.out {
+				t.Fatalf("Expected %s found %s", tt.out, actual)
+			}
+		})
+	}
+}
+
+func TestGetHostFromRepoUrlFailToParseUrl(t *testing.T) {
+	var params = []struct {
+		in  string
+		out string
+	}{
+		{
+			"http!!://abc",
+			"",
+		},
+	}
+
+	for _, tt := range params {
+		t.Run(tt.in, func(t *testing.T) {
+			actual, err := GetBaseUrl(tt.in)
+			if actual != "" {
+				t.Fatalf("Expected an empty string result")
+			}
+			if _, ok := err.(FailedToParseUrlError); !ok {
+				t.Fatalf("Expected to received error of type FailedToParseUrlError got %T", err)
+			}
+		})
+	}
+}
+
+func TestGetHostFromRepoUrlMissingSchema(t *testing.T) {
+	var params = []struct {
+		in  string
+		out string
+	}{
+		{
+			"gitlab.com",
+			"",
+		},
+		{
+			"gitlab.cee.redhat.com",
+			"",
+		},
+	}
+
+	for _, tt := range params {
+		t.Run(tt.in, func(t *testing.T) {
+			actual, err := GetBaseUrl(tt.in)
+			if actual != "" {
+				t.Fatalf("Expected an empty string result")
+			}
+			if _, ok := err.(MissingSchemaError); !ok {
+				t.Fatalf("Expected to received error of type MissingSchemaError got %T", err)
+			}
+		})
+	}
+}
+
+func TestGetHostFromRepoUrlMissingHost(t *testing.T) {
+	var params = []struct {
+		in  string
+		out string
+	}{
+		{
+			"http:///abc",
+			"",
+		},
+	}
+
+	for _, tt := range params {
+		t.Run(tt.in, func(t *testing.T) {
+			actual, err := GetBaseUrl(tt.in)
+			if actual != "" {
+				t.Fatalf("Expected an empty string result")
+			}
+			if _, ok := err.(MissingHostError); !ok {
+				t.Fatalf("Expected to received error of type MissingHostError got %T", err)
+			}
+		})
+	}
+}

--- a/pkg/git/gitproviderfactory/gitproviderfactory.go
+++ b/pkg/git/gitproviderfactory/gitproviderfactory.go
@@ -105,7 +105,11 @@ func createGitClient(gitClientConfig GitClientConfig) (gitprovider.GitProviderCl
 		if isAppUsed {
 			return nil, fmt.Errorf("GitLab does not have applications")
 		}
-		return gitlab.NewGitlabClient(accessToken)
+		baseUrl, err := gitlab.GetBaseUrl(gitClientConfig.RepoUrl)
+		if err != nil {
+			return nil, err
+		}
+		return gitlab.NewGitlabClient(accessToken, baseUrl)
 
 	case "bitbucket":
 		return nil, boerrors.NewBuildOpError(boerrors.EUnknownGitProvider, fmt.Errorf("git provider %s is not supported", gitProvider))


### PR DESCRIPTION
When creating a Gitlab client, the base url of the Gitlab instance should be provided (unless the default is used, which is https://gitlab.com). With this change, it would be possible to use Gitlab instance other than gitlab.com.

In addition, fixed an issue in "getWebhookByTargetUrl" where it tried to access a nil pointer of a request.
