### PR TITLE
remove the scoping of nudges to Applications

### DIFF
--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -279,7 +279,7 @@ func (r *ComponentDependencyUpdateReconciler) handleCompletedBuild(ctx context.C
 	componentDesc := ""
 	for i := range components.Items {
 		comp := components.Items[i]
-		if comp.Spec.Application == updatedComponent.Spec.Application && slices.Contains(updatedComponent.Spec.BuildNudgesRef, comp.Name) {
+		if slices.Contains(updatedComponent.Spec.BuildNudgesRef, comp.Name) {
 			toUpdate = append(toUpdate, comp)
 		}
 		if componentDesc != "" {


### PR DESCRIPTION
I removed the restriction that nudging can only happen between Components in the same application in HAS with https://github.com/redhat-appstudio/application-service/pull/434

This change removes that restriction from the build service as well.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable