### PR TITLE
Allow renovatebot to rebase existing PRs on staging after renaming

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -172,6 +172,7 @@ func generateConfigJS(slug string, repositories []renovateRepository, _ interfac
 				recreateClosed: true,
 				recreateWhen: "always",
 				rebaseWhen: "behind-base-branch",
+				gitIgnoredAuthors: ["rhtap-staging"],
 				enabled: true
 			  }
 			]


### PR DESCRIPTION
After renaming of renovate bot name, existing PRs on staging are not getting updates. This PR adds old bot name into exceptions to overwrite changes from, so exiting PRs could be updated.
Needs to be reverted after some time.