### PR TITLE
Rename renovate bot branch

### DIFF
--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -161,7 +161,7 @@ func generateConfigJS(slug string, repositories []renovateRepository, _ interfac
 				matchPackagePatterns: ["%s"],
 				matchDepPatterns: ["%s"],
 				groupName: "RHTAP references",
-				branchName: "rhtap/references/{{baseBranch}}",
+				branchName: "konflux/references/{{baseBranch}}",
 				commitMessageExtra: "",
 				commitMessageTopic: "RHTAP references",
 				semanticCommits: "enabled",
@@ -172,7 +172,6 @@ func generateConfigJS(slug string, repositories []renovateRepository, _ interfac
 				recreateClosed: true,
 				recreateWhen: "always",
 				rebaseWhen: "behind-base-branch",
-				gitIgnoredAuthors: ["rhtap-staging"],
 				enabled: true
 			  }
 			]


### PR DESCRIPTION
This PR changes name of the git branch used by renovate bot to create pipeline definitions update PRs.
This rename adjust branch name according to the app rename and also helps to overcome problem with renovate not recognizing own old commits (after rename). So, the renovate will create anew PR instead of updating old one.