### PR TITLE
Enable the customization of nudged files

### DIFF
--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -498,6 +498,14 @@ func generateRenovateConfigForNudge(slug string, repositories []renovateReposito
 	buildResult := context.(*BuildResult)
 
 	repositoriesData, _ := json.Marshal(repositories)
+	fileMatchParts := strings.Split(buildResult.FileMatches, ",")
+	for i := range fileMatchParts {
+		fileMatchParts[i] = strings.TrimSpace(fileMatchParts[i])
+	}
+	fileMatch, err := json.Marshal(fileMatchParts)
+	if err != nil {
+		return "", err
+	}
 	body := `
 	{{with $root := .}}
 	module.exports = {
@@ -510,7 +518,7 @@ func generateRenovateConfigForNudge(slug string, repositories []renovateReposito
     	enabledManagers: "regex",
 		customManagers: [
 			{
-            	"fileMatch": [{{.FileMatches}}],
+            	"fileMatch": {{.FileMatches}},
 				"customType": "regex",
 				"datasourceTemplate": "docker",
 				"matchStrings": [
@@ -567,7 +575,7 @@ func generateRenovateConfigForNudge(slug string, repositories []renovateReposito
 		BuiltImageTag:            buildResult.BuiltImageTag,
 		Digest:                   buildResult.Digest,
 		DistributionRepositories: buildResult.DistributionRepositories,
-		FileMatches:              buildResult.FileMatches,
+		FileMatches:              string(fileMatch),
 	}
 
 	tmpl, err := template.New("renovate").Parse(body)

--- a/controllers/component_dependency_update_controller_test.go
+++ b/controllers/component_dependency_update_controller_test.go
@@ -387,6 +387,15 @@ func createBuildPipelineRun(name string, namespace string, component string) *te
 	run.Namespace = namespace
 	run.Name = name
 	run.Spec.PipelineSpec = pipelineSpec
+	run.Spec.Params = tektonapi.Params{
+		tektonapi.Param{
+			Name: "nudge-files",
+			Value: tektonapi.ParamValue{
+				Type:     tektonapi.ParamTypeArray,
+				ArrayVal: []string{".*Dockerfile.*", ".*.yaml", ".*Containerfile.*"},
+			},
+		},
+	}
 	err := k8sClient.Create(context.TODO(), &run)
 	Expect(err).ToNot(HaveOccurred())
 	return &run

--- a/controllers/component_dependency_update_controller_test.go
+++ b/controllers/component_dependency_update_controller_test.go
@@ -383,19 +383,10 @@ func createBuildPipelineRun(name string, namespace string, component string) *te
 	}
 	run := tektonapi.PipelineRun{}
 	run.Labels = map[string]string{ComponentNameLabelName: component, PipelineRunTypeLabelName: PipelineRunBuildType}
-	run.Annotations = map[string]string{PacEventTypeAnnotationName: PacEventPushType}
+	run.Annotations = map[string]string{PacEventTypeAnnotationName: PacEventPushType, NudgeFilesAnnotationName: ".*Dockerfile.*, .*.yaml, .*Containerfile.*"}
 	run.Namespace = namespace
 	run.Name = name
 	run.Spec.PipelineSpec = pipelineSpec
-	run.Spec.Params = tektonapi.Params{
-		tektonapi.Param{
-			Name: "nudge-files",
-			Value: tektonapi.ParamValue{
-				Type:     tektonapi.ParamTypeArray,
-				ArrayVal: []string{".*Dockerfile.*", ".*.yaml", ".*Containerfile.*"},
-			},
-		},
-	}
 	err := k8sClient.Create(context.TODO(), &run)
 	Expect(err).ToNot(HaveOccurred())
 	return &run


### PR DESCRIPTION
Fixes [KFLUXBUGS-1114](https://issues.redhat.com/browse/KFLUXBUGS-1114)

To prevent us from having to continuously modify the set of files that can have nudged references, we will define the default set of files and let users customize the nudges based on pipeline parameters. There is no intention to add default values or to expose this parameter to users in the PipelineDefinition pushed out to repositories.

I chose to add these to the Tekton params even though the params are not being used by any task in the pipeline. If there is opposition to this, I can probably reimplement it as setting the parameter by annotations.

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable