### PR TITLE
increase build-service memory limit to 512MB

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,7 +58,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable