### PR TITLE
Remove outdated recreateClosed renovate config option

### DIFF
--- a/controllers/component_dependency_update_controller.go
+++ b/controllers/component_dependency_update_controller.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
 	applicationapi "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	l "github.com/redhat-appstudio/build-service/pkg/logs"
 	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
@@ -39,10 +44,6 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strconv"
-	"strings"
-	"text/template"
-	"time"
 )
 
 const (
@@ -555,7 +556,6 @@ func generateRenovateConfigForNudge(slug string, repositories []renovateReposito
 			branchName: "rhtap/component-updates/{{.ComponentName}}",
 			commitMessageTopic: "{{.ComponentName}}",
 			prFooter: "To execute skipped test pipelines write comment ` + "`/ok-to-test`" + `",
-			recreateClosed: true,
 			recreateWhen: "always",
 			rebaseWhen: "behind-base-branch",
 			enabled: true,

--- a/controllers/git_tekton_resources_renovater.go
+++ b/controllers/git_tekton_resources_renovater.go
@@ -169,7 +169,6 @@ func generateConfigJS(slug string, repositories []renovateRepository, _ interfac
 				prBodyColumns: ["Package", "Change", "Notes"],
 				prBodyDefinitions: { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '%stask-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
 				prBodyTemplate: "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
-				recreateClosed: true,
 				recreateWhen: "always",
 				rebaseWhen: "behind-base-branch",
 				enabled: true


### PR DESCRIPTION
Renovate prints warning about configuration that needs to be migrated.
`recreateClosed`  is [replaced](https://docs.renovatebot.com/configuration-options/#recreatewhen) with `recreateWhen`, which we already have in the config. This PR just removes outdated renovate config item.