### PR TITLE
chore: Update codecov version and add token

### DIFF
--- a/.github/workflows/codecov-main.yaml
+++ b/.github/workflows/codecov-main.yaml
@@ -14,4 +14,7 @@ jobs:
       - name: Run tests
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,6 +49,4 @@ jobs:
         run: make test
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3.1.1
-        with:
-          fail_ci_if_error: true
 


### PR DESCRIPTION
codecov upload started failing due to the GH rate limiting. Have to use token while uploading as suggested [here](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) , since we can only access the github secrets on push CI, so need to enable `fail_ci_if_error: false`

### Checklist:
 - PR has reference to the issue(s) it resolves
 - Write / update unit tests
 - Write / update integration (envtest) tests
 - Ensure there is an issue for e2e tests if needed
 - Ensure `make test` passes
 - Ensure test coverage hasn't decreased
 - Test code changes manually
 - Update readme and documentation
 - Write PR description that highlights overall changes and add usage examples if applicable