### PR TITLE
Respect self-hosted GitLab URL in Repository CR

### DIFF
--- a/controllers/component_build_controller_pac.go
+++ b/controllers/component_build_controller_pac.go
@@ -849,7 +849,12 @@ func generatePACRepository(component appstudiov1alpha1.Component, config map[str
 		}
 
 		if gitProvider == "gitlab" {
-			gitProviderConfig.URL = "https://gitlab.com"
+			if providerUrl, configured := component.Annotations[GitProviderAnnotationURL]; configured {
+				gitProviderConfig.URL = providerUrl
+			} else {
+				// Assume gitlab.com
+				gitProviderConfig.URL = "https://gitlab.com"
+			}
 		}
 	}
 


### PR DESCRIPTION
In case of OnPrem GitLab instance, Repository CR should respect the instance URL.